### PR TITLE
feat(plg): dev mode conditionals for regwiz js

### DIFF
--- a/dynamix.unraid.net.plg
+++ b/dynamix.unraid.net.plg
@@ -813,7 +813,7 @@ response_complete($httpcode, '{}');
 function showRegWizard() {
   <? $license_state = strtoupper(empty($var['regCheck']) ? $var['regTy'] : $var['regCheck']); ?>
   Shadowbox.open({
-    content:'https://registration-dev.unraid.net/?ts=<?=time()?>&guid=<?=$var['flashGUID']?>&state=<?=$license_state?>&keyfile=<?=str_replace(['+','/','='], ['-','_',''], trim(base64_encode(@file_get_contents($var['regFILE']))))?>&reggen=<?=$var['regGen']?>&flashproduct=<?=$var['flashProduct']?>&flashvendor=<?=$var['flashVendor']?>&registered=<?=empty($remote['apikey'])||empty($var['regFILE'])?0:1?>&servername=<?=$var['NAME']?>&serverip=<?=$_SERVER['SERVER_ADDR']?>&internalip=<?=$_SERVER['SERVER_ADDR']?>&internalport=<?=$_SERVER['SERVER_PORT']?>&protocol=<?=$_SERVER['REQUEST_SCHEME']?>&site='+location.origin+'&email=<?=$remote['email']?>', 
+    content:'https://registration.unraid.net/?ts=<?=time()?>&guid=<?=$var['flashGUID']?>&state=<?=$license_state?>&keyfile=<?=str_replace(['+','/','='], ['-','_',''], trim(base64_encode(@file_get_contents($var['regFILE']))))?>&reggen=<?=$var['regGen']?>&flashproduct=<?=$var['flashProduct']?>&flashvendor=<?=$var['flashVendor']?>&registered=<?=empty($remote['apikey'])||empty($var['regFILE'])?0:1?>&servername=<?=$var['NAME']?>&serverip=<?=$_SERVER['SERVER_ADDR']?>&internalip=<?=$_SERVER['SERVER_ADDR']?>&internalport=<?=$_SERVER['SERVER_PORT']?>&protocol=<?=$_SERVER['REQUEST_SCHEME']?>&site='+location.origin+'&email=<?=$remote['email']?>', 
     player: 'iframe',
     options: {modal: true, animate: false, displayNav: false, overlayOpacity: 0.8, viewportPadding: 0, showMovieControls: false}
   });
@@ -1011,7 +1011,7 @@ echo json_encode($arr);
 <INLINE>
 <![CDATA[
 echo "🕹️ Start download web component files"
-URL=https://registration-dev.unraid.net/wc/
+URL=https://registration.unraid.net/wc/
 MANIFEST_JSON=manifest.json
 MANIFEST_TXT=manifest.txt
 cd /usr/local/emhttp/webGui
@@ -1075,7 +1075,13 @@ unraid-user-profile {
 <![CDATA[
 <!-- user profile component -->
 <script src="https://cdn.jsdelivr.net/npm/vue"></script>
-<script src="https://registration-dev.unraid.net/wc/unraid.min.js" type="text/javascript"></script>
+<?
+$upc_dev = 0;
+$upc_file = 'https://registration.unraid.net/wc/unraid.min.js';
+if ($upc_dev === 'local') $upc_file = 'https://launchpad.unraid.test:6969/wc/unraid.min.js';
+elseif ($upc_dev) $upc_file = 'https://registration-dev.unraid.net/wc/unraid.min.js';
+?>
+<script src="<? echo $upc_file; ?>"></script>
 <!-- No internet connection fallback to filesystem version -->
 <script type="text/javascript">
 if (!window.Vue) {


### PR DESCRIPTION
This PR mainly changes registration-dev.unraid.net to registration.unraid.net which uses different values in a few ENV VARS during the Vue.js build process. These two URLs have their own DynoDB table so we have a dev and a prod table to use.

I found myself constantly having to ssh into my test server then modifying `/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php` to include a similar conditional so I could run different environments of the Vue stuff…especially when needing to test Vue locally within the webGUI. This will save me some time as now I'll only need to modify the singular variable.

Not sure if we'd want to expose these URLs in the plugin source so I'll understand if you want me to remove the conditional.