### PR TITLE
refactor(plg): converted iframe shadowbox launchpad to web component

### DIFF
--- a/dynamix.unraid.net.plg
+++ b/dynamix.unraid.net.plg
@@ -1069,7 +1069,7 @@ unraid-user-profile {
 <INLINE>
 <![CDATA[
 <!-- user profile component -->
-<?if(empty($wizard['hideWizard'])):?>
+<?if(empty($wizard['hideWizard']) || $path=='Tools/Registration'):?>
 <unraid-launchpad token="<? echo $var['csrf_token'] ?>" openonload="<? echo empty($wizard['hideWizard']) ?>"></unraid-launchpad>
 <?endif?>
 <script src="https://cdn.jsdelivr.net/npm/vue"></script>


### PR DESCRIPTION
## [PLEASE READ THIS NOTE]
This PR and https://github.com/unraid/webgui-launchpad-overlay/pull/14 are dependent on each other. Both should be "deployed" / "released" in sync…a la around the same time. 

Only MERGE when https://github.com/unraid/webgui-launchpad-overlay/pull/14 has at least been merged into the `dev` branch.

------------------

This PR removes the iframe that housed the Launchpad in favor of two async Vue.js web components 
- `<unraid-open-launchpad></unraid-open-launchpad>`
- `<unraid-launchpad></unraid-launchpad>`

These web components communicate with the existing UPC & Sign Out button web components. :)