### PR TITLE
refactor(plg): reg wiz inject in webGUI. Added ENV and better fallback

### DIFF
--- a/dynamix.unraid.net.plg
+++ b/dynamix.unraid.net.plg
@@ -1240,10 +1240,10 @@ unraid-user-profile {
 <![CDATA[
 <!-- RegWiz -->
 <script type="text/javascript">
-const UPC_ENV = localStorage.getItem('UPC_ENV') ? localStorage.getItem('UPC_ENV') : 'prod'; // @TODO - it would be great if this was auto-set when PLG was built
+const UPC_ENV = localStorage.getItem('UPC_ENV') ? localStorage.getItem('UPC_ENV') : 'production'; // @TODO - it would be great if this was auto-set when PLG was built
 const VUE_CDN_PREFIX = 'https://cdn.jsdelivr.net/npm/vue@2.6.12';
 const injectJS = (src) => {
-  if (UPC_ENV !== 'prod') console.debug('[injectJS]', src);
+  if (UPC_ENV !== 'production') console.debug('[injectJS]', src);
   const script = document.createElement('script');
   script.type = 'text/javascript';
   script.src = src;
@@ -1253,15 +1253,15 @@ const injectJS = (src) => {
 let vueFile = `${VUE_CDN_PREFIX}/dist/vue.min.js`;
 let wcEntryFile = 'https://registration.unraid.net/wc/unraid.min.js';
 // determine what source we should use
-if (UPC_ENV !== 'prod') console.debug('[UPC_ENV]', UPC_ENV);
+if (UPC_ENV !== 'production') console.debug('[UPC_ENV]', UPC_ENV);
 switch (UPC_ENV) {
-  case 'stage':
-    // min version of stage
+  case 'staging':
+    // min version of staging
     vueFile = `${VUE_CDN_PREFIX}/dist/vue.min.js`;
     wcEntryFile = 'https://registration-dev.unraid.net/wc/unraid.min.js';
     break;
-  case 'stage-debug':
-    // non-min version of stage
+  case 'staging-debug':
+    // non-min version of staging
     vueFile = `${VUE_CDN_PREFIX}/dist/vue.js`;
     wcEntryFile = 'https://registration-dev.unraid.net/wc/unraid.js';
     break;
@@ -1270,7 +1270,7 @@ switch (UPC_ENV) {
     vueFile = '<?autov('/webGui/javascript/vue.js') ?>';
     wcEntryFile = '<?autov('/webGui/wc/unraid.min.js') ?>'; // @TODO / WIP - non-min files aren't downloaded just yet.
     break;
-  case 'dev':
+  case 'development':
     // local filesystem Vue.js + external "local" dev server for RegWiz development
     vueFile = '<?autov('/webGui/javascript/vue.js') ?>';
     wcEntryFile = 'https://launchpad.unraid.test:6969/wc/unraid.js';
@@ -1291,7 +1291,7 @@ let checkForVue = setInterval(() => {
 // fallback if we take too long injecting the above
 setTimeout(() => {
   if (!window.Vue) {
-    if (UPC_ENV !== 'prod') console.debug('[UPC] fallback to filesystem JS');
+    if (UPC_ENV !== 'production') console.debug('[UPC] fallback to filesystem JS');
     clearInterval(checkForVue); // stop initial check
     injectJS("<?autov('/webGui/javascript/vue.min.js') ?>");
     checkForVue = setInterval(() => { // reset check


### PR DESCRIPTION
To change what files are loaded for the UPC and RegWiz components? In the webGUI set a `localStorage` item with the key of `UPC_ENV` with one of the following values

```
production
staging
staging-debug
local
development
```

See this `switch` for the following values and the files they load:
```js
// by default prod is loaded from hosted sources
let vueFile = `${VUE_CDN_PREFIX}/dist/vue.min.js`;
let wcEntryFile = 'https://registration.unraid.net/wc/unraid.min.js';
// determine what source we should use
if (UPC_ENV !== 'production') console.debug('[UPC_ENV]', UPC_ENV);
switch (UPC_ENV) {
  case 'staging':  // min version of stage
    vueFile = `${VUE_CDN_PREFIX}/dist/vue.min.js`;
    wcEntryFile = 'https://registration-dev.unraid.net/wc/unraid.min.js';
    break;
  case 'staging-debug': // non-min version of stage
    vueFile = `${VUE_CDN_PREFIX}/dist/vue.js`;
    wcEntryFile = 'https://registration-dev.unraid.net/wc/unraid.js';
    break;
  case 'local': // forces load from webGUI filesystem
    vueFile = `/webGui/javascript/vue.js`;
    wcEntryFile = '/webGui/wc/unraid.min.js'; // @TODO / WIP - non-min files aren't downloaded just yet.
    break;
  case 'development': // local filesystem Vue.js + external "local" dev server for RegWiz development
    vueFile = `<?autov('/webGui/javascript/vue.js') ?>`;
    wcEntryFile = 'https://launchpad.unraid.test:6969/wc/unraid.js';
    break;
  default: // production
    break;
}
```

![Screen Shot 2020-10-15 at 20 52 18](https://user-images.githubusercontent.com/2531682/96211190-7e7a8800-0f28-11eb-8517-f990f1323558.png)
![Screen Shot 2020-10-15 at 20 52 26](https://user-images.githubusercontent.com/2531682/96211201-8508ff80-0f28-11eb-9ab0-d39090146fc0.png)
![Screen Shot 2020-10-15 at 20 52 41](https://user-images.githubusercontent.com/2531682/96211205-863a2c80-0f28-11eb-9d5b-7f22b37f97ab.png)
![Screen Shot 2020-10-15 at 20 52 50](https://user-images.githubusercontent.com/2531682/96211206-86d2c300-0f28-11eb-8fc4-2ba233d4c77c.png)
![Screen Shot 2020-10-15 at 20 52 57](https://user-images.githubusercontent.com/2531682/96211208-8803f000-0f28-11eb-8639-c123eb2d7b88.png)
