### PR TITLE
update: web component js paths to prevent breaking previous versions

### DIFF
--- a/dynamix.unraid.net.plg
+++ b/dynamix.unraid.net.plg
@@ -33,12 +33,12 @@ if [ -e /etc/rc.d/rc.unraid-api ]; then
   mv -f /usr/local/emhttp/plugins/dynamix.unraid.net/Registration.page- /usr/local/emhttp/plugins/dynamix/Registration.page
   mv -f /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php- /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php
   mv -f /usr/local/emhttp/plugins/dynamix/DisplaySettings.page- /usr/local/emhttp/plugins/dynamix/DisplaySettings.page
-  rm -rf /boot/config/plugins/Unraid.net/webComps
   rm -f /boot/config/plugins/Unraid.net/unraid-api.tgz
   rm -f /boot/config/plugins/Unraid.net/.gitignore
   rm -rf /usr/local/emhttp/plugins/dynamix.unraid.net
   rm -f /usr/local/emhttp/webGui/javascript/vue.js
   rm -f /usr/local/emhttp/webGui/javascript/vue.min.js
+  rm -rf /boot/config/plugins/Unraid.net/webComps
   rm -rf /usr/local/emhttp/webGui/webComps
   rm -rf /boot/config/plugins/Unraid.net/wc
   rm -rf /usr/local/emhttp/webGui/wc


### PR DESCRIPTION
paired with https://github.com/unraid/vuejs-regwiz/commit/a88cc34e2b745e2d31dad88a990a35831aed60c6

This prevents breaking the web components for people without the upcoming PLG release when the next release of RegWiz goes to production.

- non-async web components (latest method of loading into webgui) will now be built at dist/webComps
- async web components will continue to be built at dist/wc

So we updated the paths to the non-async files.