### PR TITLE
fix: return no servers from endpoint to reset cache

### DIFF
--- a/src/graphql/schema/utils.ts
+++ b/src/graphql/schema/utils.ts
@@ -77,16 +77,16 @@ const getLocalServer = (): [CachedServer] => {
 };
 
 export const getServers = async (): Promise<Server[]> => {
-	// Check if we have the servers already cached, if so return them
-	const cachedServers = userCache.get<CachedServers>('mine')?.servers;
-	if (cachedServers) return cachedServers;
-
 	// For now use the my_servers key
 	// Later we should return the correct one for the current user with the correct scope, etc.
 	const apiKey = apiManager.cloudKey;
 
 	// Return only current server if we have no key
 	if (!apiKey) return getLocalServer();
+
+	// Check if we have the servers already cached, if so return them
+	const cachedServers = userCache.get<CachedServers>('mine')?.servers;
+	if (cachedServers) return cachedServers;
 
 	// No cached servers found
 	if (!cachedServers) {


### PR DESCRIPTION
- when signed out, return no servers when api key is not present
this will reset the dependency cycle and should fix the online /
offline status checks

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202778317548727