### PR TITLE
Feat/detect permission denied

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/UpdateFlashBackup.php
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/UpdateFlashBackup.php
@@ -566,7 +566,7 @@ if (($command == 'update') || ($command == 'reinit')) {
     }
     if ($return_var != 0) {
       // check for permission denied
-      if (strpos($push_output,'permission denied') !== false) {
+      if (stripos($push_output,'permission denied') !== false) {
         $arrState['error'] = 'Permission Denied';
       } else {
         $arrState['error'] = 'Failed to sync flash backup';


### PR DESCRIPTION
Ensure that "permission denied" errors are surfaced to users rather than something generic like "Failed to sync flash backup"

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203271557085046