### PR TITLE
fix: stop all api's on uninstall/upgrade

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -299,6 +299,7 @@ fi
 if [ -e /etc/rc.d/rc.unraid-api ]; then
   # Stop all services
   /etc/rc.d/rc.flash_backup stop &>/dev/null
+  kill -9 `pidof unraid-api` &>/dev/null
   /etc/rc.d/rc.unraid-api uninstall
   # Uninstall the main source package
   [[ -f "/var/log/packages/${MAINNAME}" ]] && removepkg --terse "${MAINNAME}"

--- a/plugin/plugins/dynamix.unraid.net.staging.plg
+++ b/plugin/plugins/dynamix.unraid.net.staging.plg
@@ -299,6 +299,7 @@ fi
 if [ -e /etc/rc.d/rc.unraid-api ]; then
   # Stop all services
   /etc/rc.d/rc.flash_backup stop &>/dev/null
+  kill -9 `pidof unraid-api` &>/dev/null
   /etc/rc.d/rc.unraid-api uninstall
   # Uninstall the main source package
   [[ -f "/var/log/packages/${MAINNAME}" ]] && removepkg --terse "${MAINNAME}"


### PR DESCRIPTION
On older versions of the API, `unraid-api stop` will only stop the first instance