### PR TITLE
refactor: move docker events to store

### DIFF
--- a/api/src/graphql/index.ts
+++ b/api/src/graphql/index.ts
@@ -4,11 +4,8 @@
  */
 
 import { FatalAppError } from '@app/core/errors/fatal-error';
-import { DockerEventEmitter } from '@gridplus/docker-events';
-import { User } from '@app/core/types/states/user';
-import { dockerLogger, graphqlLogger, logger } from '@app/core/log';
+import { graphqlLogger } from '@app/core/log';
 import { modules } from '@app/core';
-import { pubsub } from '@app/core/pubsub';
 import { getters } from '@app/store';
 
 export const getCoreModule = (moduleName: string) => {
@@ -31,47 +28,3 @@ export const apiKeyToUser = async (apiKey: string) => {
 
 	return { id: -1, description: 'A guest user', name: 'guest', role: 'guest' };
 };
-
-// Only watch container events equal to start/stop
-const watchedEvents = [
-	'die',
-	'kill',
-	'oom',
-	'pause',
-	'restart',
-	'start',
-	'stop',
-	'unpause',
-].map(event => `event=${event}`);
-
-// Create docker event emitter instance
-logger.addContext('events', watchedEvents);
-logger.debug('Creating docker event emitter instance');
-logger.removeContext('events');
-
-// @TODO: Move this to store
-const dee = new DockerEventEmitter(watchedEvents);
-
-// On Docker event update info with { apps: { installed, started } }
-dee.on('*', async (data: { Type: 'container'; Action: 'start' | 'stop'; from: string }) => {
-	// Only listen to container events
-	if (data.Type !== 'container') {
-		dockerLogger.debug(`[${data.Type as string}] ${data.from} ${data.Action}`);
-		return;
-	}
-
-	dockerLogger.addContext('data', data);
-	dockerLogger.debug(`[${data.from}] ${data.Type}->${data.Action}`);
-	dockerLogger.removeContext('data');
-
-	const user: User = { id: '-1', description: 'Internal service account', name: 'internal', role: 'admin', password: false };
-	const { json } = await modules.getAppCount({ user });
-	await pubsub.publish('info', {
-		info: {
-			apps: json,
-		},
-	});
-});
-
-logger.debug('Binding to docker events');
-dee.listen();

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ import { app, httpServer, server } from '@app/server';
 import { config } from '@app/core/config';
 import { unlinkSync } from 'fs';
 import { fileExistsSync } from '@app/core/utils/files/file-exists';
+import { setupDockerWatch } from '@app/store/watch/docker-watch';
 
 // Boot app
 void am(async () => {
@@ -52,6 +53,9 @@ void am(async () => {
 
 	// Start listening to key file changes
 	setupRegistrationKeyWatch();
+
+	// Start listening to docker events
+	setupDockerWatch();
 
 	// Try and load the HTTP server
 	logger.debug('Starting HTTP server');

--- a/api/src/store/index.ts
+++ b/api/src/store/index.ts
@@ -7,6 +7,7 @@ import { emhttp } from '@app/store/modules/emhttp';
 import { registration } from '@app/store/modules/registration';
 import { cache } from '@app/store/modules/cache';
 import { dashboard } from '@app/store/modules/dashboard';
+import { docker } from '@app/store/modules/docker';
 
 export const store = configureStore({
 	reducer: {
@@ -18,6 +19,7 @@ export const store = configureStore({
 		registration: registration.reducer,
 		cache: cache.reducer,
 		dashboard: dashboard.reducer,
+		docker: docker.reducer,
 	},
 	middleware: getDefaultMiddleware => getDefaultMiddleware({
 		serializableCheck: {
@@ -39,4 +41,5 @@ export const getters = {
 	registration: () => store.getState().registration,
 	cache: () => store.getState().cache,
 	dashboard: () => store.getState().dashboard,
+	docker: () => store.getState().docker,
 };

--- a/api/src/store/modules/docker.ts
+++ b/api/src/store/modules/docker.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import merge from 'lodash/merge';
+import type { ContainerInfo } from 'dockerode';
+import { DaemonConnectionStatus } from '@app/store/types';
+
+type DockerState = {
+	status: DaemonConnectionStatus;
+	installed: number | null;
+	running: number | null;
+	containers: ContainerInfo[];
+};
+
+const initialState: DockerState = {
+	status: DaemonConnectionStatus.DISCONNECTED,
+	installed: null,
+	running: null,
+	containers: [],
+};
+
+export const docker = createSlice({
+	name: 'docker',
+	initialState,
+	reducers: {
+		updateDockerState(state, action: PayloadAction<Partial<typeof initialState>>) {
+			return merge(state, action.payload);
+		},
+	},
+});
+
+export const { updateDockerState } = docker.actions;

--- a/api/src/store/store-sync.ts
+++ b/api/src/store/store-sync.ts
@@ -6,6 +6,7 @@ import { setupConfigPathWatch } from './watch/config-watch';
 import { FileLoadStatus } from './types';
 import { syncRegistration } from '@app/store/sync/registration-sync';
 import { syncArray } from '@app/store/sync/array-sync';
+import { syncInfoApps } from '@app/store/sync/info-apps-sync';
 
 export const startStoreSync = async () => {
 	// The last state is stored so we don't end up in a loop of writing -> reading -> writing
@@ -31,6 +32,9 @@ export const startStoreSync = async () => {
 
 			// Update array
 			await syncArray(lastState);
+
+			// Update docker app counts
+			await syncInfoApps(lastState);
 		}
 
 		lastState = state;

--- a/api/src/store/sync/info-apps-sync.ts
+++ b/api/src/store/sync/info-apps-sync.ts
@@ -1,0 +1,44 @@
+import { logger } from '@app/core/log';
+import { pubsub } from '@app/core/pubsub';
+import { store } from '@app/store';
+import { DaemonConnectionStatus, StoreSubscriptionHandler } from '@app/store/types';
+import { isEqual } from 'lodash';
+
+type InfoAppsEvent = {
+	info: {
+		apps: {
+			installed: number | null;
+			running: number | null;
+		};
+	};
+};
+
+export const createInfoAppsEvent = (state: Parameters<StoreSubscriptionHandler>[0]): InfoAppsEvent | null => {
+	// Docker state isn't loaded
+	if (state === null || state.docker.status === DaemonConnectionStatus.DISCONNECTED) return null;
+
+	return {
+		info: {
+			apps: {
+				installed: state?.docker.installed,
+				running: state?.docker.running,
+			},
+		},
+	};
+};
+
+export const syncInfoApps: StoreSubscriptionHandler = async lastState => {
+	const lastEvent = createInfoAppsEvent(lastState);
+	const currentEvent = createInfoAppsEvent(store.getState());
+
+	// Skip if either event resolved to null
+	if (lastEvent === null || currentEvent === null) return;
+
+	// Skip this if it's the same as the last one
+	if (isEqual(lastEvent, currentEvent)) return;
+
+	logger.debug('Docker container count was updated, publishing event');
+
+	// Publish to graphql
+	await pubsub.publish('info', currentEvent);
+};

--- a/api/src/store/types.ts
+++ b/api/src/store/types.ts
@@ -52,7 +52,11 @@ export interface StateFileToIniParserMap {
 	[StateFileKey.users]: (state: UsersIni) => Users;
 	[StateFileKey.sec]: (state: SmbIni) => SmbShares;
 	[StateFileKey.sec_nfs]: (state: NfsSharesIni) => NfsShares;
+}
 
+export enum DaemonConnectionStatus {
+	CONNECTED = 'CONNECTED',
+	DISCONNECTED = 'DISCONNECTED',
 }
 
 export type StoreSubscriptionHandler = (lastState: RootState | null) => Promise<void>;

--- a/api/src/store/watch/docker-watch.ts
+++ b/api/src/store/watch/docker-watch.ts
@@ -1,0 +1,52 @@
+import { store } from '@app/store';
+import { DockerEventEmitter } from '@gridplus/docker-events';
+import { dockerLogger } from '@app/core/log';
+import { docker } from '@app/core/utils/clients/docker';
+import { updateDockerState } from '@app/store/modules/docker';
+
+type ContainerState = 'created' | 'running' | 'exited';
+
+export const setupDockerWatch = () => {
+	// Only watch container events equal to start/stop
+	const watchedEvents = [
+		'die',
+		'kill',
+		'oom',
+		'pause',
+		'restart',
+		'start',
+		'stop',
+		'unpause',
+	].map(event => `event=${event}`);
+
+	// Create docker event emitter instance
+	dockerLogger.addContext('events', watchedEvents);
+	dockerLogger.debug('Creating docker event emitter instance');
+	dockerLogger.removeContext('events');
+
+	const dee = new DockerEventEmitter(watchedEvents);
+
+	// On Docker event update info with { apps: { installed, started } }
+	dee.on('*', async (data: { Type: 'container'; Action: 'start' | 'stop'; from: string }) => {
+		// Only listen to container events
+		if (data.Type !== 'container') {
+			dockerLogger.debug(`[${data.Type as string}] ${data.from} ${data.Action}`);
+			return;
+		}
+
+		dockerLogger.addContext('data', data);
+		dockerLogger.debug(`[${data.from}] ${data.Type}->${data.Action}`);
+		dockerLogger.removeContext('data');
+
+		// Get all of the current containers
+		const containers = await docker.listContainers({ all: true });
+		const installed = containers.length;
+		const running = containers.filter(container => container.State as ContainerState === 'running').length;
+
+		// Update state
+		store.dispatch(updateDockerState({ containers, installed, running }));
+	});
+
+	dockerLogger.debug('Binding to docker events');
+	dee.listen();
+};


### PR DESCRIPTION
This moves the docker events emitter to store watch/sync functions.