### PR TITLE
style(plugin): warning for host not in allowed origins

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/MyServers.page
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/MyServers.page
@@ -388,7 +388,7 @@ $allowedOriginsArr = stripos($allowedOrigins.",", "/".$host.",") === false ? exp
 <? if ($allowedOriginsArr): ?>
 <dl>
   <div style="margin-bottom: 2rem;">
-    <span class="warning"><i class='fa fa-warning fa-fw'></i> <strong>_(Warning)_</strong></span> <?= sprintf(_('Your current url **%s** is not in the list of allowed origins for this server'), $host) ?>.
+    <span class="orange-text"><i class='fa fa-warning fa-fw'></i> <strong>_(Warning)_</strong></span> <?= sprintf(_('Your current url **%s** is not in the list of allowed origins for this server'), $host) ?>.
     <br/>_(For best results, use one of these urls)_:
     <dd>
       <ul>


### PR DESCRIPTION
- Readability of warning message a bit. I started to style this as a warning component type thing with background color, bumped up text size, etc. to help the warning stand out more as you scroll down the page. But I withheld from that because it's not something that really exists in the webGUI (that I know of) and didn't want to creep on scope with a full on new addition to styling.

- Clean up of the template that hopefully helps with code readability and maintenance. Moving forward we shouldn't conform too much to the existing code style of the webGUI as it's often hard to traverse. May not have been your intention but it was a tad hard to read – though the logic was solid 😄 . So here's my take on it.

- Setup for translations. Added to English repo: https://github.com/unraid/lang-en_US/pull/160

## Test instructions
1. open webgui terminal / ssh
2. `rm -rf /usr/local/emhttp/plugins/dynamix.my.servers/MyServers.page`
3. `nano /usr/local/emhttp/plugins/dynamix.my.servers/MyServers.page`
4. View full file of changes from PR
5. Copy it
6. Go back to the terminal
7. Paste
8. `ctrl+x` (Exit nano)
9. Press `Y` key (to confirm changes)
10. Press `Return` key (to confirm filename)
11. Go back to webgui and reload

<img width="690" alt="Screen Shot 2023-01-04 at 23 19 49" src="https://user-images.githubusercontent.com/2531682/210724644-ee84fbff-8b7f-44a6-bed9-47e3e8a34d0b.png">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203644083520604