### PR TITLE
refactor: plugin install always use production UPC

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/myservers1.php
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/myservers1.php
@@ -72,14 +72,15 @@ if (upcEnvCookie) console.debug('[UPC_ENV] ✨', upcEnvCookie);
 
 // If the UPC isn't defined after 3secs inject UPC via
 setTimeout(() => {
-  if (!window.customElements.get('unraid-user-profile')) {
-    console.log('[UPC] Fallback to filesystem src 😖');
-    const el = document.createElement('script');
-    el.type = 'text/javascript';
-    el.src = '<?=$upcLocalSrc?>';
-    document.head.appendChild(el);
-    return upcEnv('local', false, true); // set session cookie to prevent delayed loads of UPC
-  }
+  // UPC exists do nothing
+  if (window.customElements.get('unraid-user-profile')) return;
+
+  console.log('[UPC] Fallback to filesystem src 😖');
+  const el = document.createElement('script');
+  el.type = 'text/javascript';
+  el.src = '<?=$upcLocalSrc?>';
+  document.head.appendChild(el);
+  return upcEnv('local', false, true); // set session cookie to prevent delayed loads of UPC
 }, 3000);
 
 function upcEnv(str, reload = true, session = false) { // overwrite upc src


### PR DESCRIPTION
line 45 in the old version was the culprit for all the users not getting the production UPC. They were all signed out…

Larry and I determined that integrating `navigator.onLine` would add a lot of complication that we don't need to deal with right now.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204124403825132