### PR TITLE
refactor: Registration page link order

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/Registration.page
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/Registration.page
@@ -1,4 +1,4 @@
-Menu="About"
+Menu="About:30"
 Type="xmenu"
 Title="Registration"
 Icon="icon-registration"


### PR DESCRIPTION
Puts the Tools > Registration link third in the list of links in it's section on the Tools page after Downgrade & Update OS links.