### PR TITLE
fix: state connect values without connect installed

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/state.php
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/state.php
@@ -250,7 +250,7 @@ class ServerState
                 "date" => @$this->getWebguiGlobal('display', 'date') ?? '',
                 "time" => @$this->getWebguiGlobal('display', 'time') ?? '',
             ],
-            "description" => $this->var['COMMENT'] ? htmlspecialchars($this->var['COMMENT']) : '',
+            "description" => $this->var['COMMENT'] ? htmlspecialchars($this->var['COMMENT'], ENT_HTML5) : '',
             "deviceCount" => $this->var['deviceCount'],
             "email" => $this->email,
             "expireTime" => 1000 * (($this->var['regTy'] === 'Trial' || strstr($this->var['regTy'], 'expired')) ? $this->var['regTm2'] : 0),
@@ -264,8 +264,8 @@ class ServerState
             "keyfile" => $this->keyfileBase64UrlSafe,
             "lanIp" => ipaddr(),
             "locale" => (!empty($_SESSION) && $_SESSION['locale']) ? $_SESSION['locale'] : 'en_US',
-            "model" => $this->var['SYS_MODEL'],
-            "name" => htmlspecialchars($this->var['NAME']),
+            "model" => $this->var['SYS_MODEL'] ? htmlspecialchars($this->var['SYS_MODEL'], ENT_HTML5) : '',
+            "name" => htmlspecialchars($this->var['NAME'], ENT_HTML5),
             "osVersion" => $this->osVersion,
             "osVersionBranch" => $this->osVersionBranch,
             "protocol" => _var($_SERVER, 'REQUEST_SCHEME'),
@@ -273,7 +273,7 @@ class ServerState
             "regDev" => @(int)$this->var['regDev'] ?? 0,
             "regGen" => @(int)$this->var['regGen'],
             "regGuid" => @$this->var['regGUID'] ?? '',
-            "regTo" => @htmlspecialchars($this->var['regTo']) ?? '',
+            "regTo" => @htmlspecialchars($this->var['regTo'], ENT_HTML5) ?? '',
             "regTm" => $this->var['regTm'] ? @$this->var['regTm'] * 1000 : '', // JS expects milliseconds
             "regTy" => @$this->var['regTy'] ?? '',
             "regExp" => $this->var['regExp'] ? @$this->var['regExp'] * 1000 : '', // JS expects milliseconds


### PR DESCRIPTION
## Explanation of bug 1
This fixes an error a specific subset of users may be experiencing – see https://forums.unraid.net/topic/154030-6128-log-spammed-with-references-to-unraid-apiphp/

If a user previously had a historic Unraid Connect / My Servers installed and was signed in, then eventually removed the plugin without explicitly signing out first there could have been an instance where the `myservers.cfg` may not have been cleared / removed. (Note that the plugin clears the cfg file…don't know the specific version where that was introduced)

Our file to serve the web components the server details was not correctly configured to handle this instance.

So because the myservers.cfg file may have Unraid.net account details in it the webgui web components were assuming it should be calling the `unraid-api` to keep it's data store up to data. But because the `unraid-api` doesn't exist on the system, the same web components receive an error that the `unraid-api` is "offline". And because it thinks it's installed, the web components attempt to restart the `unraid-api` which then resulted in the 404 bug that was showing up in the syslog.

## Bug 2
Detailed here – https://app.asana.com/0/inbox/1159909068082281/1206646230784096/1206647094911789