### PR TITLE
fix: unraid-api missing start command + var defaults

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/unraid-api.php
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/unraid-api.php
@@ -49,7 +49,7 @@ if ($cli) {
   if ($argc > 2) $param1 = $argv[2];
 } else {
   $command = $_POST['command'];
-  $param1 = $_POST['param1'];
+  $param1 = $_POST['param1'] ?? '';
 }
 if (!in_array($command, $validCommands)) $command = 'none';
 


### PR DESCRIPTION
- `start` was missing the `exec` to run the command
- also added default values for `$output` & `$retval`. Felt weird to ref a var that hadn't been made yet. Perhaps this isn't needed
- also update plg name in error output

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206670478791168