### PR TITLE
refactor: upgrade action button for unleashed to lifetime

### DIFF
--- a/web/store/server.ts
+++ b/web/store/server.ts
@@ -487,6 +487,7 @@ export const useServerStore = defineStore('server', () => {
           actions: [
             ...(!registered.value && connectPluginInstalled.value ? [signInAction.value] : []),
             ...(regUpdatesExpired.value ? [renewAction.value] : []),
+            ...(state.value === 'UNLEASHED' ? [upgradeAction.value] : []),
             ...(registered.value && connectPluginInstalled.value ? [signOutAction.value] : []),
           ],
           humanReadable: state.value === 'PRO'


### PR DESCRIPTION
When originally built we weren't going to allow Unleashed to Lifetime upgrades. But instead were going to tell people to buy a new lifetime key outright.

This change will render the Upgrade button for Unleashed users.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206853545576740