### PR TITLE
fix: flash backup activated detection in account payload

### DIFF
--- a/web/store/server.ts
+++ b/web/store/server.ts
@@ -268,6 +268,7 @@ export const useServerStore = defineStore('server', () => {
       connectPluginVersion: connectPluginVersion.value,
       description: description.value,
       expireTime: expireTime.value,
+      flashBackupActivated: flashBackupActivated.value,
       flashProduct: flashProduct.value,
       flashVendor: flashVendor.value,
       guid: guid.value,

--- a/web/types/server.ts
+++ b/web/types/server.ts
@@ -124,6 +124,7 @@ export interface ServerAccountCallbackSendPayload {
   description?: string;
   deviceCount?: number;
   expireTime?: number;
+  flashBackupActivated?: boolean;
   flashProduct?: string;
   flashVendor?: string;
   guid?: string;


### PR DESCRIPTION
`flashBackupActivated` somehow got missed from my callback server payload to the account app. So the sign out of connect page hasn't been warning people that they had this feature enabled and that it'll become disabled.