### PR TITLE
feat: add date formatting helper

### DIFF
--- a/api/src/graphql/generated/api/operations.ts
+++ b/api/src/graphql/generated/api/operations.ts
@@ -591,6 +591,7 @@ export function NotificationSchema(): z.ZodObject<Properties<Notification>> {
   return z.object({
     __typename: z.literal('Notification').optional(),
     description: z.string(),
+    formattedTimestamp: z.string().nullish(),
     id: z.string(),
     importance: ImportanceSchema,
     link: z.string().nullish(),

--- a/api/src/graphql/generated/api/types.ts
+++ b/api/src/graphql/generated/api/types.ts
@@ -817,6 +817,7 @@ export type Node = {
 export type Notification = Node & {
   __typename?: 'Notification';
   description: Scalars['String']['output'];
+  formattedTimestamp?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   importance: Importance;
   link?: Maybe<Scalars['String']['output']>;
@@ -2403,6 +2404,7 @@ export type NodeResolvers<ContextType = Context, ParentType extends ResolversPar
 
 export type NotificationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Notification'] = ResolversParentTypes['Notification']> = ResolversObject<{
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  formattedTimestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   importance?: Resolver<ResolversTypes['Importance'], ParentType, ContextType>;
   link?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/api/src/graphql/schema/types/notifications/notifications.graphql
+++ b/api/src/graphql/schema/types/notifications/notifications.graphql
@@ -17,15 +17,21 @@ type Query {
 type Mutation {
     createNotification(input: NotificationData!): Notification!
     deleteNotification(id: String!, type: NotificationType!): NotificationOverview!
-    """Marks a notification as archived."""
+    """
+    Marks a notification as archived.
+    """
     archiveNotification(id: String!): Notification!
-    """Marks a notification as unread."""
+    """
+    Marks a notification as unread.
+    """
     unreadNotification(id: String!): Notification!
     archiveNotifications(ids: [String!]): NotificationOverview!
     unarchiveNotifications(ids: [String!]): NotificationOverview!
     archiveAll(importance: Importance): NotificationOverview!
     unarchiveAll(importance: Importance): NotificationOverview!
-    """Reads each notification to recompute & update the overview."""
+    """
+    Reads each notification to recompute & update the overview.
+    """
     recalculateOverview: NotificationOverview!
 }
 
@@ -42,7 +48,9 @@ enum Importance {
 
 type Notifications implements Node {
     id: ID!
-    """A cached overview of the notifications in the system & their severity."""
+    """
+    A cached overview of the notifications in the system & their severity.
+    """
     overview: NotificationOverview!
     list(filter: NotificationFilter!): [Notification!]!
 }
@@ -62,6 +70,7 @@ type Notification implements Node {
     ISO Timestamp for when the notification occurred
     """
     timestamp: String
+    formattedTimestamp: String
 }
 
 input NotificationData {

--- a/api/src/unraid-api/graph/resolvers/notifications/notifications.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/notifications/notifications.resolver.ts
@@ -45,7 +45,7 @@ export class NotificationsResolver {
         const notifications = await this.notificationsService.getNotifications(filters);
         return notifications.map((notification) => ({
             ...notification,
-            timestamp: formatTimestamp(notification.timestamp),
+            formattedTimestamp: formatTimestamp(notification.timestamp),
         }));
     }
 

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -103,7 +103,7 @@ export function updateObject(
 }
 
 /**
- * Formats a timestamp into a human readable format: "MMM D, YYYY"
+ * Formats a timestamp into a human-readable format: "MMM D, YYYY"
  * Example: "Oct 24, 2024"
  *
  * @param timestamp - ISO date string or Unix timestamp in seconds


### PR DESCRIPTION
This PR adds a `formatTimestamp` utility function for formatting timestamps into a human readable format. Also applies the `formatTimestamp` function to the list resolver before sending to the client.

```
{
  "id": "8cbfe7fcd0b04cda9062e9e1e053708cd1c6502b37490d215ed2cfa0f8df9617:Unraid_Parity_check_1683971161.notify",
  "title": "Unraid Parity check",
  "subject": "Notice [UNRAID] - Parity check finished (0 errors)",
  "description": "Canceled",
  "importance": "WARNING",
  "link": "/",
  "type": "UNREAD",
  "timestamp": "2023-05-13T09:46:01.000Z",
  "formattedTimestamp": "May 13, 2023"
}
```