### PR TITLE
fix(web): reset infinite scroll when notification filters change

### DIFF
--- a/web/components/Notifications/List.vue
+++ b/web/components/Notifications/List.vue
@@ -21,7 +21,13 @@ const props = withDefaults(
   }
 );
 
+/** whether we should continue trying to load more notifications */
 const canLoadMore = ref(true);
+/** reset custom state when props (e.g. props.type filter) change*/
+watch(props, () => {
+  canLoadMore.value = true;
+});
+
 const { result, error, fetchMore } = useQuery(getNotifications, () => ({
   filter: {
     offset: 0,


### PR DESCRIPTION
fixes a bug where infinite scroll wouldn't trigger after it stopped, even when changing filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced loading functionality for notifications, allowing for better management of loading states.
	- Introduced a mechanism to prevent loading more notifications when none are available.

- **Bug Fixes**
	- Improved error handling during notification fetching, with logging for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->