### PR TITLE
feat(web): move notification indicator icons to top-right of bell icon

### DIFF
--- a/web/components/Notifications/Indicator.vue
+++ b/web/components/Notifications/Indicator.vue
@@ -2,7 +2,6 @@
 import { BellIcon, ExclamationTriangleIcon, ShieldExclamationIcon } from '@heroicons/vue/24/solid';
 import { cn } from '~/components/shadcn/utils';
 import { Importance, type OverviewQuery } from '~/composables/gql/graphql';
-import { onWatcherCleanup } from 'vue';
 
 const props = defineProps<{ overview?: OverviewQuery['notifications']['overview'] }>();
 
@@ -37,25 +36,6 @@ const icon = computed<{ component: Component; color: string } | null>(() => {
   }
   return null;
 });
-
-/** whether new notifications ocurred */
-const hasNewNotifications = ref(false);
-// watch for new notifications, set a temporary indicator when they're reveived
-watch(
-  () => props.overview?.unread,
-  (newVal, oldVal) => {
-    if (!newVal || !oldVal) {
-      return;
-    }
-    hasNewNotifications.value = newVal.total > oldVal.total;
-    // lifetime of 'new notification' state
-    const msToLive = 30_000;
-    const timeout = setTimeout(() => {
-      hasNewNotifications.value = false;
-    }, msToLive);
-    onWatcherCleanup(() => clearTimeout(timeout));
-  }
-);
 </script>
 
 <template>


### PR DESCRIPTION
previously, icons were placed next to bell icon because the status indicators were not accessible to color-blind users. this commit replaces circular status indicators with the icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified notification indicator logic for improved performance and clarity.
	- Enhanced rendering of notification indicators based on the 'UNREAD' state.

- **Bug Fixes**
	- Removed unnecessary timeout mechanism for clearing notification states. 

- **Style**
	- Adjusted CSS classes for notification indicators to align with new rendering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
![image](https://github.com/user-attachments/assets/aa0641d8-174e-4ed6-800e-a7050a791d8d)
![image](https://github.com/user-attachments/assets/35be1553-64df-4bd6-afb4-4cb226930e46)
![image](https://github.com/user-attachments/assets/9018b1ea-54bc-4f5f-9da2-68fd3c8a1b76)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208937564886430