### PR TITLE
feat(web): rm old notification bell upon plugin installation

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -466,6 +466,7 @@ preserveFilesDirs=(
   "move:/usr/local/emhttp/plugins/dynamix.my.servers/data/server-state.php:preventDowngrade"
   "move:/usr/local/emhttp/plugins/dynamix.my.servers/include/reboot-details.php:preventDowngrade"
   "move:/usr/local/emhttp/plugins/dynamix.my.servers/include/translations.php:preventDowngrade"
+  "copy:/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php:preventDowngrade"
 )
 
 preserveAction() {


### PR DESCRIPTION
- strips notification-bell related lines from DefaultPageLayout
- preserves (ie backs up) DefaultPageLayout upon installation
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208799100466938