### PR TITLE
feat(web): clear notifications indicator after opening sidebar

### DIFF
--- a/web/components/Notifications/Indicator.vue
+++ b/web/components/Notifications/Indicator.vue
@@ -3,7 +3,7 @@ import { BellIcon, ExclamationTriangleIcon, ShieldExclamationIcon } from '@heroi
 import { cn } from '~/components/shadcn/utils';
 import { Importance, type OverviewQuery } from '~/composables/gql/graphql';
 
-const props = defineProps<{ overview?: OverviewQuery['notifications']['overview'] }>();
+const props = defineProps<{ overview?: OverviewQuery['notifications']['overview'], seen?: boolean }>();
 
 const indicatorLevel = computed(() => {
   if (!props.overview?.unread) {
@@ -42,12 +42,12 @@ const icon = computed<{ component: Component; color: string } | null>(() => {
   <div class="relative">
     <BellIcon class="w-6 h-6 text-header-text-primary" />
     <div
-      v-if="indicatorLevel === 'UNREAD'"
+      v-if="!seen && indicatorLevel === 'UNREAD'"
       class="absolute top-0 right-0 size-2.5 rounded-full border border-neutral-800 bg-unraid-green"
     />
     <component
       :is="icon.component"
-      v-else-if="icon && indicatorLevel"
+      v-else-if="!seen && icon && indicatorLevel"
       :class="cn('absolute -top-1 -right-1 size-4 rounded-full', icon.color)"
     />
   </div>

--- a/web/components/Notifications/Sidebar.vue
+++ b/web/components/Notifications/Sidebar.vue
@@ -39,13 +39,32 @@ const overview = computed(() => {
   }
   return result.value.notifications.overview;
 });
+
+/** whether user has viewed their notifications */
+const hasSeenNotifications = ref(false);
+
+// renews unseen state when new notifications arrive
+watch(
+  () => overview.value?.unread,
+  (newVal, oldVal) => {
+    if (!newVal || !oldVal) return;
+    if (newVal.total > oldVal.total) {
+      hasSeenNotifications.value = false;
+    }
+  }
+);
+
+const prepareToViewNotifications = () => {
+  determineTeleportTarget();
+  hasSeenNotifications.value = true;
+};
 </script>
 
 <template>
   <Sheet>
-    <SheetTrigger @click="determineTeleportTarget">
+    <SheetTrigger @click="prepareToViewNotifications">
       <span class="sr-only">Notifications</span>
-      <NotificationsIndicator :overview="overview" />
+      <NotificationsIndicator :overview="overview" :seen="hasSeenNotifications" />
     </SheetTrigger>
     <SheetContent
       :to="teleportTarget"


### PR DESCRIPTION
Clears notification indicator in upc after opening sidebar (including warning/alert state). Comes back if new notifications arrive.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208699364164612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced notification tracking with a new `seen` state
	- Added ability to track whether user has viewed notifications

- **Bug Fixes**
	- Improved notification visibility logic to prevent unnecessary indicator displays

- **Refactor**
	- Updated notification component to provide more precise rendering conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->