### PR TITLE
fix(web): escaping html-encoded symbols like apostrophes in translations

### DIFF
--- a/web/components/I18nHost.ce.vue
+++ b/web/components/I18nHost.ce.vue
@@ -2,6 +2,7 @@
 import en_US from '~/locales/en_US.json';
 import { provide } from 'vue';
 import { createI18n, I18nInjectionKey } from 'vue-i18n';
+import { createHtmlEntityDecoder } from '~/helpers/i18n-utils';
 
 // import ja from '~/locales/ja.json';
 
@@ -26,7 +27,6 @@ if (windowLocaleData) {
   }
 }
 
-const parser = new DOMParser();
 const i18n = createI18n<false>({
   legacy: false, // must set to `false`
   locale: nonDefaultLocale ? parsedLocale : defaultLocale,
@@ -37,12 +37,7 @@ const i18n = createI18n<false>({
     ...(nonDefaultLocale ? parsedMessages : {}),
   },
   /** safely decodes html-encoded symbols like &amp; and &apos; */
-  postTranslation(translated) {
-    if (typeof translated !== 'string') return translated;
-    // parseFromString interprets the string as HTML, then textContent reads the decoded text
-    const decoded = parser.parseFromString(translated, 'text/html').documentElement.textContent;
-    return decoded ?? translated;
-  },
+  postTranslation: createHtmlEntityDecoder(),
 });
 
 provide(I18nInjectionKey, i18n);

--- a/web/helpers/i18n-utils.ts
+++ b/web/helpers/i18n-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a post-translation function that decodes HTML entities in translated strings.
+ * This function is typically used with createI18n to handle HTML-encoded translations.
+ * 
+ * @returns A function that takes a translated value and decodes any HTML entities if it's a string.
+ *          If the input is not a string, it returns the original value unchanged.
+ * 
+ * @example
+ * const decode = createHtmlEntityDecoder();
+ * decode("&amp;"); // Returns "&"
+ * decode(123); // Returns 123
+ * const i18n = createI18n({
+ *  // ... other options
+ *  postTranslation(translated) {
+ *   return decode(translated);
+ *  },
+ * });
+ */
+export const createHtmlEntityDecoder = () => {
+    const parser = new DOMParser();
+    return <T>(translated: T) => {
+        if (typeof translated !== 'string') return translated;
+        const decoded = parser.parseFromString(translated, 'text/html').documentElement.textContent;
+        return decoded ?? translated;
+    };
+};

--- a/web/plugins/i18n.ts
+++ b/web/plugins/i18n.ts
@@ -1,7 +1,7 @@
 import { createI18n } from 'vue-i18n';
 
 import en_US from '@/locales/en_US.json'; 
-const parser = new DOMParser();
+import { createHtmlEntityDecoder } from '~/helpers/i18n-utils';
 
 export default defineNuxtPlugin(({ vueApp }) => {
   const i18n = createI18n({
@@ -12,12 +12,7 @@ export default defineNuxtPlugin(({ vueApp }) => {
     messages: {
       en_US,  
     },
-    postTranslation(translated) {
-      if (typeof translated !== 'string') return translated;
-      // parseFromString interprets the string as HTML, then textContent reads the decoded text
-      const decoded = parser.parseFromString(translated, 'text/html').documentElement.textContent;
-      return decoded ?? translated; // fallback if somehow it's null
-    }
+    postTranslation: createHtmlEntityDecoder(),
   });
 
   vueApp.use(i18n);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced internationalization (i18n) support with improved HTML entity decoding in translated strings.
	- Implemented a robust mechanism to safely decode HTML-encoded symbols during translation.

- **Bug Fixes**
	- Resolved potential issues with HTML entities in translated content by adding a post-translation parsing step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->