### PR TITLE
feat(web): open official release notes via header os version

### DIFF
--- a/web/components/HeaderOsVersion.ce.vue
+++ b/web/components/HeaderOsVersion.ce.vue
@@ -10,7 +10,7 @@ import { useI18n } from 'vue-i18n';
 import 'tailwindcss/tailwind.css';
 import '~/assets/main.css';
 
-import { WEBGUI_TOOLS_DOWNGRADE, WEBGUI_TOOLS_UPDATE } from '~/helpers/urls';
+import { getReleaseNotesUrl, WEBGUI_TOOLS_DOWNGRADE, WEBGUI_TOOLS_UPDATE } from '~/helpers/urls';
 import { useServerStore } from '~/store/server';
 import { useUpdateOsStore } from '~/store/updateOs';
 import { useUpdateOsActionsStore } from '~/store/updateOsActions';
@@ -70,10 +70,12 @@ const updateOsStatus = computed(() => {
 
 <template>
   <div class="flex flex-row justify-start gap-x-4px">
-    <button
+    <a
       class="group leading-none"
       :title="t('View release notes')"
-      @click="updateOsActionsStore.viewReleaseNotes(t('{0} Release Notes', [osVersion]))"
+      :href="getReleaseNotesUrl(osVersion).toString()"
+      target="_blank"
+      rel="noopener"
     >
       <UiBadge
         color="custom"
@@ -84,7 +86,7 @@ const updateOsStatus = computed(() => {
       >
         {{ osVersion }}
       </UiBadge>
-    </button>
+    </a>
     <component
       :is="updateOsStatus.href ? 'a' : 'button'"
       v-if="updateOsStatus"

--- a/web/helpers/urls.ts
+++ b/web/helpers/urls.ts
@@ -24,6 +24,17 @@ const WEBGUI_TOOLS_UPDATE = new URL('/Tools/Update', WEBGUI);
 const OS_RELEASES = new URL(import.meta.env.VITE_OS_RELEASES ?? 'https://releases.unraid.net/os');
 
 const DOCS_RELEASE_NOTES = new URL('/go/release-notes/', DOCS);
+
+/**
+ * @param version - An Unraid OS version string (x.x.x-suffix). 
+ *   Suffix indicates special releases, such as RCs or betas.
+ * @returns A URL object pointing to the release notes for the specified Unraid OS version.
+ */
+const getReleaseNotesUrl = (version: string): URL => {
+  const osVersion = version.split('-')[0];
+  return new URL(`/unraid-os/release-notes/${osVersion}`, DOCS);
+}
+
 const DOCS_REGISTRATION_LICENSING = new URL('/go/faq-licensing/', DOCS);
 const DOCS_REGISTRATION_REPLACE_KEY = new URL('/go/changing-the-flash-device/', DOCS);
 
@@ -43,6 +54,7 @@ export {
   OS_RELEASES,
   DOCS,
   DOCS_RELEASE_NOTES,
+  getReleaseNotesUrl,
   DOCS_REGISTRATION_LICENSING,
   DOCS_REGISTRATION_REPLACE_KEY,
   WEBGUI,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced release notes navigation by adding a direct link to OS version release notes.
	- Improved URL generation for accessing release notes with version-specific targeting.

- **Documentation**
	- Added JSDoc comments to clarify function behavior for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->