### PR TITLE
fix: logrotate error

### DIFF
--- a/api/src/core/logrotate/setup-logrotate.ts
+++ b/api/src/core/logrotate/setup-logrotate.ts
@@ -1,4 +1,5 @@
 import { writeFile } from 'fs/promises';
+
 import { fileExists } from '@app/core/utils/files/file-exists';
 
 export const setupLogRotation = async () => {
@@ -8,12 +9,13 @@ export const setupLogRotation = async () => {
         await writeFile(
             '/etc/logrotate.d/unraid-api',
             `
-            /var/log/unraid-api/*.log {
-                rotate 1
-                missingok
-                size 5M
-            }
-        `,
+/var/log/unraid-api/*.log {
+    rotate 1
+    missingok
+    size 5M
+    su root root
+}
+`,
             { mode: '644' }
         );
     }


### PR DESCRIPTION
# Fixes: 

error: skipping "/var/log/unraid-api/unraid-api.log" because parent =<br />directory has insecure permissions (It's world writable or writable by =<br />group which is not "root") Set "su" directive in config file to =<br />tell logrotate which user/group should be used for rotation.<br />

# Improvements

No longer indents logrotate.conf for unraid-api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated log rotation configuration to improve system logging management
  - Added user and group specification for log rotation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->