### PR TITLE
fix(web): flash of disconnected api state on page load

### DIFF
--- a/web/store/unraidApi.ts
+++ b/web/store/unraidApi.ts
@@ -1,4 +1,4 @@
-import { type ApolloClient as ApolloClientType, type NormalizedCacheObject } from '@apollo/client';
+import type { ApolloClient as ApolloClientType, NormalizedCacheObject } from '@apollo/client';
 import { ArrowPathIcon } from '@heroicons/vue/24/solid';
 import { WebguiUnraidApiCommand } from '~/composables/services/webgui';
 import { client } from '~/helpers/create-apollo-client';
@@ -20,7 +20,7 @@ export const useUnraidApiStore = defineStore('unraidApi', () => {
   const unraidApiClient = ref<ApolloClientType<NormalizedCacheObject> | null>(client);
 
   // const unraidApiErrors = ref<any[]>([]);
-  const unraidApiStatus = ref<'connecting' | 'offline' | 'online' | 'restarting'>('offline');
+  const unraidApiStatus = ref<'connecting' | 'offline' | 'online' | 'restarting'>('connecting');
   const prioritizeCorsError = ref(false); // Ensures we don't overwrite this specific error message with a non-descriptive network error message
 
   const offlineError = computed(() => {


### PR DESCRIPTION
Changes initial unraidApiStatus to connecting instead of offline. This prevents a flash of the offline state on page loads and navigation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209142891304910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Updated initial API connection state to start in a 'connecting' status instead of 'offline'
	- Refined TypeScript import syntax for type declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->