### PR TITLE
fix(web): remove warn and error console log removal

### DIFF
--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -80,6 +80,8 @@ export default defineNuxtConfig({
 
   vite: {
     plugins: [
+      // Only remove non-critical console methods when VITE_ALLOW_CONSOLE_LOGS is false
+      // Keeps console.warn and console.error for debugging purposes
       !process.env.VITE_ALLOW_CONSOLE_LOGS &&
         removeConsole({
           includes: ['log', 'info', 'debug'],


### PR DESCRIPTION
Feels like allowing both error and warn to not be stripped out is a good thing.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209152979110364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Updated Vite plugin configuration to modify console logging behavior during development.
	- Adjusted log suppression settings to retain 'log', 'info', and 'debug' messages while allowing warnings and errors to be displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->