### PR TITLE
fix: PHP Warning in state.php

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/state.php
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/include/state.php
@@ -124,7 +124,7 @@ class ServerState
     /**
      * Retrieve the value of a webgui global setting.
      */
-    public function getWebguiGlobal(string $key, string $subkey = null)
+    public function getWebguiGlobal(string $key, ?string $subkey = null)
     {
         if (!$subkey) {
             return _var($this->webguiGlobals, $key, '');


### PR DESCRIPTION
PHP 8.4.4 (Unraid 7.1.0): Implicitly marking parameter $subkey as nullable is deprecated

Related: https://github.com/unraid/webgui/pull/2009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal handling of optional details, enhancing system robustness and flexibility when certain inputs are omitted. This update contributes to smoother, more reliable operations without affecting visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->