### PR TITLE
fix(api): change log output location for diagnostic compatibility

### DIFF
--- a/api/ecosystem.config.json
+++ b/api/ecosystem.config.json
@@ -12,8 +12,7 @@
             "min_uptime": 10000,
             "watch": false,
             "ignore_watch": ["node_modules", "src", ".env.*", "myservers.cfg"],
-            "out_file": "/var/log/graphql-api.log",
-            "error_file": "/var/log/unraid-api/unraid-api.error.log",
+            "log_file": "/var/log/graphql-api.log",
             "kill_timeout": 10000
         }
     ]


### PR DESCRIPTION
now outputs logs to `/var/log/graphql-api.log` instead of `/var/log/unraid-api/unraid-api.log`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209371065526320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the logging file destination to `/var/log/graphql-api.log`.
  - Streamlined configuration formatting for enhanced clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->