### PR TITLE
fix/plugin-always-restores

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -349,6 +349,7 @@ echo "⚠️ Do not close this window yet"
 echo
 
 if [ -e /etc/rc.d/rc.unraid-api ]; then
+  touch /tmp/restore-files-dynamix-unraid-net
   # stop flash backup
   /etc/rc.d/rc.flash_backup stop &>/dev/null
   # stop the api gracefully
@@ -386,7 +387,7 @@ fi
     <![CDATA[
     echo "Restoring Files"
 
-if [ -e /etc/rc.d/rc.unraid-api ]; then
+if [ -f /tmp/restore-files-dynamix-unraid-net ]; then
   # restore stock files
   FILES_TO_RESTORE=(
     "/usr/local/emhttp/plugins/dynamix/DisplaySettings.page"
@@ -455,6 +456,7 @@ if [ -e /etc/rc.d/rc.unraid-api ]; then
   sed -i '/scripts\/makestate/d' /etc/rc.d/rc.nginx
   # clean up extra origin for robots.txt
   sed -i '#robots.txt any origin/d' /etc/rc.d/rc.nginx
+  rm /tmp/restore-files-dynamix-unraid-net
 fi
 exit 0
 ]]>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the plugin uninstallation process to ensure that system files are properly restored during removal. This update uses a temporary flag to trigger restoration only when needed and cleans up afterward, ensuring a smooth and reliable uninstallation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->