### PR TITLE
fix: update brand loading variants for consistent sizing

### DIFF
--- a/unraid-ui/src/components/brand/brand-loading.variants.ts
+++ b/unraid-ui/src/components/brand/brand-loading.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority';
 
-export const brandLoadingVariants = cva('inline-flex items-center justify-center w-full h-full aspect-[133.52/76.97]', {
+export const brandLoadingVariants = cva('inline-flex items-center justify-center w-full h-full aspect-[7/4]', {
   variants: {
     variant: {
       default: '',


### PR DESCRIPTION
I was seeing strange behavior on /Tools/Registration when forcing the check that happens on page load to fire again. The brand logo SVG was rendering very large. So I set the size to small. But the SVG was still rendering strangely due to the square width and height classes.

In the SVG source code, I took `viewBox="0 0 133.52 76.97"` and converted that to an aspect ratio, `133.52/76.97`. And for simpler integers - `133.52/76.97 ≈ 1.735` which is close to `7/4 (1.75)`. So we can use - `aspect-[7/4]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the brand loading component’s appearance by enforcing a consistent aspect ratio and streamlining its dimension settings to focus solely on width parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->