### PR TITLE
make log viewer vertically resizable

### DIFF
--- a/web/components/Logs/LogViewer.ce.vue
+++ b/web/components/Logs/LogViewer.ce.vue
@@ -103,7 +103,7 @@ const onSelectOpen = () => {
 
 <template>
   <div
-    class="flex flex-col h-full min-h-[400px] resize-y bg-background text-foreground rounded-lg border border-border overflow-hidden"
+    class="flex flex-col h-[500px] resize-y bg-background text-foreground rounded-lg border border-border overflow-hidden"
   >
     <div class="p-4 border-b border-border">
       <h2 class="text-lg font-semibold mb-4">Log Viewer</h2>

--- a/web/components/Logs/SingleLogViewer.vue
+++ b/web/components/Logs/SingleLogViewer.vue
@@ -399,7 +399,7 @@ defineExpose({ refreshLogContent });
       v-else
       ref="scrollViewportRef"
       v-infinite-scroll="[loadMoreContent, { direction: 'top', distance: 200, canLoadMore: () => shouldLoadMore }]"
-      class="flex-1 overflow-y-auto max-h-[500px]"
+      class="flex-1 overflow-y-auto"
       :class="{ 'theme-dark': isDarkMode, 'theme-light': !isDarkMode }"
     >
       <!-- Loading indicator for loading more content -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The log viewer now starts at a fixed size and supports vertical resizing, giving users more control over the viewing area.
  - The single log display has been updated to remove height restrictions, allowing for a more flexible and extended view of log content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->