### PR TITLE
feat: ReplaceKey functionality in Registration and Update pages

### DIFF
--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/Registration.page
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.my.servers/Registration.page
@@ -14,6 +14,9 @@ Tag="pencil"
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  */
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
+$replaceKey = new ReplaceKey();
+$replaceKey->check();
 ?>
 <unraid-i18n-host>
   <unraid-registration></unraid-registration>

--- a/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.plugin.manager/Update.page
+++ b/plugin/source/dynamix.unraid.net/usr/local/emhttp/plugins/dynamix.plugin.manager/Update.page
@@ -14,7 +14,10 @@ Tag="upload"
  * all copies or substantial portions of the Software.
  */
 require_once "$docroot/plugins/dynamix.my.servers/include/reboot-details.php";
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
 $rebootDetails = new RebootDetails();
+$replaceKey = new ReplaceKey();
+$replaceKey->check();
 ?>
 <script>
 function cleanUpFlashBackup(zip) {


### PR DESCRIPTION
- Handles auto-extensions key check and install of extend license key with new OS Updates Expiration date

Related to https://github.com/unraid/webgui/pull/2071 but not 100% dependent on them.

@elibosley, do we want to use the `force` param on the `check()` method for either of these pages?

Additionally, what do you think about any potential integration with `UnraidCheck.php` – which is used for the UPC's "Check for Updates" button and the user configured automatically scheduled update check? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced plugin registration and update processes with an integrated key validation step that verifies system parameters automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209573221367688