### PR TITLE
fix: node installation not persisting across reboots

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -134,7 +134,7 @@ exit 0
         fi
 
         # Remove all node js archives from the flashdrive that do not match the expected version
-        find /boot/config/plugins/dynamix.my.servers/ -name "node-v*-linux-x64.tar.xz" ! -name "&NODEJS_FILENAME;" -delete
+        find /boot/config/plugins/dynamix.my.servers/ -name "node-v*-linux-x64.tar.xz" ! -name "${NODE_FILE}" -delete
 
 
         echo "Node.js installation successful"


### PR DESCRIPTION
thank you to SteveHawk on the unraid.net forums for surfacing this: https://forums.unraid.net/topic/188319-persist-node-package-download/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the plugin’s file-cleanup process by correcting the reference used to identify outdated Node.js archive files. This update ensures that file management functions as intended, contributing to more reliable plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->