### PR TITLE
fix: .env.production from allowing console logs on build

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -2,5 +2,3 @@ VITE_ACCOUNT=https://account.unraid.net
 VITE_CONNECT=https://connect.myunraid.net
 VITE_UNRAID_NET=https://unraid.net
 VITE_CALLBACK_KEY=Uyv2o8e*FiQe8VeLekTqyX6Z*8XonB
-# Keep console logs until components are stabilized
-VITE_ALLOW_CONSOLE_LOGS=true


### PR DESCRIPTION
`VITE_ALLOW_CONSOLE_LOGS` should not be present in `.env.production`. We don't want basic debugs logs in prod.

Found this because the latest OS release `7.1.0-beta.1.6` which included the latest web components had debug logs included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled non-essential console logging in the production environment for a cleaner runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->