### PR TITLE
chore: update license fields in package.json

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -31,7 +31,6 @@
         "codegen:watch": "DOTENV_CONFIG_PATH='./.env.staging' graphql-codegen --config codegen.ts --watch -r dotenv/config",
         "codegen:local": "NODE_TLS_REJECT_UNAUTHORIZED=0  MOTHERSHIP_GRAPHQL_LINK='https://mothership.localhost/ws' graphql-codegen --config codegen.ts --watch",
         "// Code Quality": "",
-        "compliance": "pnpx license-checker --excludePrivatePackages --direct --production --onlyAllow=\"MIT;BSD-2-Clause;BSD-3-Clause;ISC;Apache-2.0;Zlib;X11;Python-2.0;Artistic-2.0;PostgreSQL;GPL-2.0-or-later;GPL-3.0;AGPL-3.0;LGPL-2.1;LGPL-3.0\"",
         "lint": "eslint --config .eslintrc.ts src/",
         "lint:fix": "eslint --fix --config .eslintrc.ts src/",
         "type-check": "tsc --noEmit",

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ stop-ignoring file:
 list-ignored:
     -git ls-files -v | grep '^S'
 
-# Masks output of `pnpm compliance` for brevity.
+# Checks a node.js project's compliance with GPL-2.0-or-later.
 [no-cd]
-compliance:
-    @sh -c 'if output=$(pnpm compliance 2>&1); then echo "Compliance check succeeded"; else echo "$output" >&2; exit 1; fi'
+@compliance:
+    pnpx license-checker --excludePrivatePackages --direct --production --onlyAllow="MIT;BSD-2-Clause;BSD-3-Clause;ISC;Apache-2.0;Zlib;X11;Python-2.0;Artistic-2.0;PostgreSQL;GPL-2.0-or-later;GPL-3.0;AGPL-3.0;LGPL-2.1;LGPL-3.0"

--- a/packages/unraid-api-plugin-health/package.json
+++ b/packages/unraid-api-plugin-health/package.json
@@ -8,6 +8,6 @@
   },
   "keywords": [],
   "author": "Lime Technology, Inc. <unraid.net>",
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "description": "Example Health plugin for Unraid API"
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -14,7 +14,7 @@
     "zx": "^8.3.2"
   },
   "type": "module",
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "scripts": {
     "// Build scripts": "",
     "build": "pnpm run build:txz && pnpm run build:plugin && ./scripts/output-local-url.sh",

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Make sure the following software is installed before proceeding.
 * Bash
 * Docker (for macOS folks, Orbstack works too)
 * [Node.js (v20)][Node-url]
-* [Just](https://github.com/casey/just)
+* [Just](https://github.com/casey/just) (optional)
 * libvirt (macOS folks can run `brew install libvirt`)
 * An [Unraid][Unraid-url] server for development
 

--- a/unraid-ui/justfile
+++ b/unraid-ui/justfile
@@ -1,3 +1,5 @@
+set fallback
+
 default: list-commands
 
 list-commands:

--- a/unraid-ui/package.json
+++ b/unraid-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@unraid/ui",
   "version": "4.4.1",
   "private": true,
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@unraid/web",
   "version": "4.4.1",
   "private": true,
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "scripts": {
     "// Development": "",
     "predev": "pnpm --filter=@unraid/ui build",


### PR DESCRIPTION
Sets license for all node.js packages to `GPL-2.0-or-later`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified license compliance verification by removing legacy script logic.
  - Updated licensing terms across components to GPL-2.0-or-later for broader compatibility.
- **Documentation**
  - Revised setup instructions to indicate that the use of the Just build tool is now optional.
- **New Features**
  - Added fallback support in the build automation tool to ensure smoother operations when targets are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->