### PR TITLE
fix: move docker mutations to the mutations resolver

### DIFF
--- a/api/src/graphql/generated/api/operations.ts
+++ b/api/src/graphql/generated/api/operations.ts
@@ -503,7 +503,6 @@ export function DockerSchema(): z.ZodObject<Properties<Docker>> {
     __typename: z.literal('Docker').optional(),
     containers: z.array(DockerContainerSchema()).nullish(),
     id: z.string(),
-    mutations: DockerMutationsSchema(),
     networks: z.array(DockerNetworkSchema()).nullish()
   })
 }

--- a/api/src/graphql/generated/api/types.ts
+++ b/api/src/graphql/generated/api/types.ts
@@ -559,7 +559,6 @@ export type Docker = Node & {
   __typename?: 'Docker';
   containers?: Maybe<Array<DockerContainer>>;
   id: Scalars['ID']['output'];
-  mutations: DockerMutations;
   networks?: Maybe<Array<DockerNetwork>>;
 };
 
@@ -835,6 +834,7 @@ export type Mutation = {
   deleteNotification: NotificationOverview;
   /** Delete a user */
   deleteUser?: Maybe<User>;
+  docker?: Maybe<DockerMutations>;
   enableDynamicRemoteAccess: Scalars['Boolean']['output'];
   login?: Maybe<Scalars['String']['output']>;
   /** Pause parity check */
@@ -2476,7 +2476,6 @@ export type DisplayResolvers<ContextType = Context, ParentType extends Resolvers
 export type DockerResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Docker'] = ResolversParentTypes['Docker']> = ResolversObject<{
   containers?: Resolver<Maybe<Array<ResolversTypes['DockerContainer']>>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  mutations?: Resolver<ResolversTypes['DockerMutations'], ParentType, ContextType>;
   networks?: Resolver<Maybe<Array<ResolversTypes['DockerNetwork']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -2694,6 +2693,7 @@ export type MutationResolvers<ContextType = Context, ParentType extends Resolver
   deleteArchivedNotifications?: Resolver<ResolversTypes['NotificationOverview'], ParentType, ContextType>;
   deleteNotification?: Resolver<ResolversTypes['NotificationOverview'], ParentType, ContextType, RequireFields<MutationdeleteNotificationArgs, 'id' | 'type'>>;
   deleteUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationdeleteUserArgs, 'input'>>;
+  docker?: Resolver<Maybe<ResolversTypes['DockerMutations']>, ParentType, ContextType>;
   enableDynamicRemoteAccess?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationenableDynamicRemoteAccessArgs, 'input'>>;
   login?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MutationloginArgs, 'password' | 'username'>>;
   pauseParityCheck?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;

--- a/api/src/graphql/schema/types/docker/docker.graphql
+++ b/api/src/graphql/schema/types/docker/docker.graphql
@@ -9,10 +9,12 @@ type Query {
 }
 
 type DockerMutations {
-    startContainer(id: ID!): DockerContainer!
-    stopContainer(id: ID!): DockerContainer!
+    """ Stop a container """
+    stop(id: ID!): DockerContainer!
+    """ Start a container """
+    start(id: ID!): DockerContainer!
 }
 
-extend type Docker {
-    mutations: DockerMutations!
+type Mutation {
+    docker: DockerMutations
 }

--- a/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.spec.ts
@@ -19,8 +19,8 @@ describe('DockerMutationsResolver', () => {
                 {
                     provide: DockerService,
                     useValue: {
-                        startContainer: vi.fn(),
-                        stopContainer: vi.fn(),
+                        start: vi.fn(),
+                        stop: vi.fn(),
                     },
                 },
             ],
@@ -34,7 +34,7 @@ describe('DockerMutationsResolver', () => {
         expect(resolver).toBeDefined();
     });
 
-    it('should start container', async () => {
+    it('should start', async () => {
         const mockContainer: DockerContainer = {
             id: '1',
             autoStart: false,
@@ -46,14 +46,14 @@ describe('DockerMutationsResolver', () => {
             state: ContainerState.RUNNING,
             status: 'Up 2 hours',
         };
-        vi.mocked(dockerService.startContainer).mockResolvedValue(mockContainer);
+        vi.mocked(dockerService.start).mockResolvedValue(mockContainer);
 
-        const result = await resolver.startContainer('1');
+        const result = await resolver.start('1');
         expect(result).toEqual(mockContainer);
-        expect(dockerService.startContainer).toHaveBeenCalledWith('1');
+        expect(dockerService.start).toHaveBeenCalledWith('1');
     });
 
-    it('should stop container', async () => {
+    it('should stop', async () => {
         const mockContainer: DockerContainer = {
             id: '1',
             autoStart: false,
@@ -65,10 +65,10 @@ describe('DockerMutationsResolver', () => {
             state: ContainerState.EXITED,
             status: 'Exited',
         };
-        vi.mocked(dockerService.stopContainer).mockResolvedValue(mockContainer);
+        vi.mocked(dockerService.stop).mockResolvedValue(mockContainer);
 
-        const result = await resolver.stopContainer('1');
+        const result = await resolver.stop('1');
         expect(result).toEqual(mockContainer);
-        expect(dockerService.stopContainer).toHaveBeenCalledWith('1');
+        expect(dockerService.stop).toHaveBeenCalledWith('1');
     });
 });

--- a/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.ts
@@ -9,23 +9,23 @@ import { DockerService } from '@app/unraid-api/graph/resolvers/docker/docker.ser
 export class DockerMutationsResolver {
     constructor(private readonly dockerService: DockerService) {}
 
-    @ResolveField('startContainer')
+    @ResolveField('start')
     @UsePermissions({
         action: AuthActionVerb.UPDATE,
         resource: Resource.DOCKER,
         possession: AuthPossession.ANY,
     })
-    public async startContainer(@Args('id') id: string) {
-        return this.dockerService.startContainer(id);
+    public async start(@Args('id') id: string) {
+        return this.dockerService.start(id);
     }
 
-    @ResolveField('stopContainer')
+    @ResolveField('stop')
     @UsePermissions({
         action: AuthActionVerb.UPDATE,
         resource: Resource.DOCKER,
         possession: AuthPossession.ANY,
     })
-    public async stopContainer(@Args('id') id: string) {
-        return this.dockerService.stopContainer(id);
+    public async stop(@Args('id') id: string) {
+        return this.dockerService.stop(id);
     }
 }

--- a/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
@@ -70,8 +70,4 @@ describe('DockerResolver', () => {
         expect(dockerService.getContainers).toHaveBeenCalledWith({ useCache: false });
     });
 
-    it('should return mutations object with id', () => {
-        const result = resolver.mutations();
-        expect(result).toEqual({ id: 'docker-mutations' });
-    });
 });

--- a/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
@@ -69,5 +69,4 @@ describe('DockerResolver', () => {
         expect(result).toEqual(mockContainers);
         expect(dockerService.getContainers).toHaveBeenCalledWith({ useCache: false });
     });
-
 });

--- a/api/src/unraid-api/graph/resolvers/docker/docker.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.resolver.ts
@@ -35,11 +35,4 @@ export class DockerResolver {
     public async networks() {
         return this.dockerService.getNetworks({ useCache: false });
     }
-
-    @ResolveField()
-    public mutations() {
-        return {
-            id: 'docker-mutations',
-        };
-    }
 }

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -183,7 +183,7 @@ describe('DockerService', () => {
         mockListContainers.mockResolvedValue(mockContainers);
         mockContainer.start.mockResolvedValue(undefined);
 
-        const result = await service.startContainer('abc123def456');
+        const result = await service.start('abc123def456');
 
         expect(result).toEqual({
             id: 'abc123def456',
@@ -234,7 +234,7 @@ describe('DockerService', () => {
         mockListContainers.mockResolvedValue(mockContainers);
         mockContainer.stop.mockResolvedValue(undefined);
 
-        const result = await service.stopContainer('abc123def456');
+        const result = await service.stop('abc123def456');
 
         expect(result).toEqual({
             id: 'abc123def456',
@@ -254,7 +254,7 @@ describe('DockerService', () => {
             mounts: [],
         });
 
-        expect(mockContainer.stop).toHaveBeenCalled();
+        expect(mockContainer.stop).toHaveBeenCalledWith({ t: 10 });
         expect(mockListContainers).toHaveBeenCalledWith({
             all: true,
             size: true,
@@ -265,8 +265,8 @@ describe('DockerService', () => {
         mockListContainers.mockResolvedValue([]);
         mockContainer.start.mockResolvedValue(undefined);
 
-        await expect(service.startContainer('abc123def456')).rejects.toThrow(
-            'Container abc123def456 not found after starting'
+        await expect(service.start('not-found')).rejects.toThrow(
+            'Container not-found not found after starting'
         );
     });
 
@@ -274,8 +274,8 @@ describe('DockerService', () => {
         mockListContainers.mockResolvedValue([]);
         mockContainer.stop.mockResolvedValue(undefined);
 
-        await expect(service.stopContainer('abc123def456')).rejects.toThrow(
-            'Container abc123def456 not found after stopping'
+        await expect(service.stop('not-found')).rejects.toThrow(
+            'Container not-found not found after stopping'
         );
     });
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
@@ -151,13 +151,19 @@ export class DockerService implements OnModuleInit {
                 id: container.Id,
                 image: container.Image,
                 status: container.Status,
-
             },
             { deep: true }
         );
     }
 
-    public async getContainers({ useCache = false, all = true, size = true, ...listOptions }: Partial<ContainerListingOptions> = { useCache: false }): Promise<DockerContainer[]> {
+    public async getContainers(
+        {
+            useCache = false,
+            all = true,
+            size = true,
+            ...listOptions
+        }: Partial<ContainerListingOptions> = { useCache: false }
+    ): Promise<DockerContainer[]> {
         if (useCache && this.containerCache.length > 0) {
             this.logger.debug('Using docker container cache');
             return this.containerCache;
@@ -219,7 +225,9 @@ export class DockerService implements OnModuleInit {
             // Refresh the containers list on each attempt
             containers = await this.getContainers({ useCache: false });
             updatedContainer = containers.find((c) => c.id === id);
-            this.logger.debug(`Container ${id} state after stop attempt ${i+1}: ${updatedContainer?.state}`);
+            this.logger.debug(
+                `Container ${id} state after stop attempt ${i + 1}: ${updatedContainer?.state}`
+            );
             if (updatedContainer?.state === ContainerState.EXITED) {
                 return updatedContainer;
             }

--- a/api/src/unraid-api/graph/resolvers/mutation/mutation.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/mutation/mutation.resolver.ts
@@ -8,4 +8,11 @@ export class MutationResolver {
             __typename: 'ArrayMutations',
         };
     }
+
+    @ResolveField()
+    public async docker() {
+        return {
+            __typename: 'DockerMutations',
+        };
+    }
 }


### PR DESCRIPTION
Thanks to @S3ppo on Discord for flagging this issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated mutation field that centralizes Docker operations via the API.
	- Added a new method for Docker-related mutations in the mutation resolver.

- **Refactor**
	- Streamlined Docker container controls by renaming the start/stop operations for improved clarity.
	- Removed legacy fields to provide a more unified mutation interface.

- **Bug Fixes**
	- Enhanced error handling during container start/stop operations to ensure consistent behavior.

- **Tests**
	- Updated test cases to reflect the new naming and behavior, ensuring reliable Docker operation validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->