### PR TITLE
fix: hide reboot notice for patch releases

### DIFF
--- a/web/components/UserProfile/CallbackFeedback.vue
+++ b/web/components/UserProfile/CallbackFeedback.vue
@@ -341,7 +341,7 @@ const showUpdateEligibility = computed(() => {
             </p>
 
             <p
-              v-if="callbackUpdateRelease?.version?.includes('patch')"
+              v-if="!callbackUpdateRelease?.version?.includes('patch')"
               class="text-14px italic opacity-75"
             >
               {{

--- a/web/components/UserProfile/CallbackFeedback.vue
+++ b/web/components/UserProfile/CallbackFeedback.vue
@@ -340,7 +340,10 @@ const showUpdateEligibility = computed(() => {
               {{ t('New Version: {0}', [callbackUpdateRelease?.name]) }}
             </p>
 
-            <p class="text-14px italic opacity-75">
+            <p
+              v-if="callbackUpdateRelease?.version?.includes('patch')"
+              class="text-14px italic opacity-75"
+            >
               {{
                 callbackTypeDowngrade
                   ? t('This downgrade will require a reboot')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the user feedback display to conditionally show the reboot reminder based on the update version type, ensuring accurate messaging for both update and downgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->