### PR TITLE
fix: sso unreliable if API outputs more than raw json

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/.login.php.modified.snapshot.php
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/.login.php.modified.snapshot.php
@@ -34,12 +34,12 @@ function verifyUsernamePasswordAndSSO(string $username, string $password): bool 
 
         try {
             // Split on first { and take everything after it
-            const jsonPart = $output[0].split('{', 2);
-            if (jsonPart.length < 2) {
+            $jsonParts = explode('{', $output[0], 2);
+            if (count($jsonParts) < 2) {
                 my_logger("SSO Login Attempt Failed: No JSON found in response");
                 return false;
             }
-            $response = json_decode('{' + $jsonPart[1], true);
+            $response = json_decode('{' . $jsonParts[1], true);
             if (isset($response['valid']) && $response['valid'] === true) {
                 return true;
             }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/.login.php.modified.snapshot.php
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/.login.php.modified.snapshot.php
@@ -33,7 +33,13 @@ function verifyUsernamePasswordAndSSO(string $username, string $password): bool 
         }
 
         try {
-            $response = json_decode($output[0], true);
+            // Split on first { and take everything after it
+            const jsonPart = $output[0].split('{', 2);
+            if (jsonPart.length < 2) {
+                my_logger("SSO Login Attempt Failed: No JSON found in response");
+                return false;
+            }
+            $response = json_decode('{' + $jsonPart[1], true);
             if (isset($response['valid']) && $response['valid'] === true) {
                 return true;
             }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/patches/sso.patch
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/patches/sso.patch
@@ -2,7 +2,7 @@ Index: /usr/local/emhttp/plugins/dynamix/include/.login.php
 ===================================================================
 --- /usr/local/emhttp/plugins/dynamix/include/.login.php	original
 +++ /usr/local/emhttp/plugins/dynamix/include/.login.php	modified
-@@ -1,6 +1,51 @@
+@@ -1,6 +1,57 @@
  <?php
 +
 +
@@ -38,7 +38,13 @@ Index: /usr/local/emhttp/plugins/dynamix/include/.login.php
 +        }
 +
 +        try {
-+            $response = json_decode($output[0], true);
++            // Split on first { and take everything after it
++            const jsonPart = $output[0].split('{', 2);
++            if (jsonPart.length < 2) {
++                my_logger("SSO Login Attempt Failed: No JSON found in response");
++                return false;
++            }
++            $response = json_decode('{' + $jsonPart[1], true);
 +            if (isset($response['valid']) && $response['valid'] === true) {
 +                return true;
 +            }
@@ -54,7 +60,7 @@ Index: /usr/local/emhttp/plugins/dynamix/include/.login.php
  // Only start a session to check if they have a cookie that looks like our session
  $server_name = strtok($_SERVER['HTTP_HOST'],":");
  if (!empty($_COOKIE['unraid_'.md5($server_name)])) {
-@@ -202,11 +247,11 @@
+@@ -202,11 +253,11 @@
              if ($failCount == $maxFails) my_logger("Ignoring login attempts for {$username} from {$remote_addr}");
              throw new Exception(_('Too many invalid login attempts'));
          }
@@ -67,7 +73,7 @@ Index: /usr/local/emhttp/plugins/dynamix/include/.login.php
          if (isWildcardCert() && $twoFactorRequired && !verifyTwoFactorToken($username, $token)) throw new Exception(_('Invalid 2FA token'));
  
          // Successful login, start session
-@@ -536,10 +581,11 @@
+@@ -536,10 +587,11 @@
                              document.body.textContent = '';
                              document.body.appendChild(errorElement);
                          }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/patches/sso.patch
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/patches/sso.patch
@@ -39,12 +39,12 @@ Index: /usr/local/emhttp/plugins/dynamix/include/.login.php
 +
 +        try {
 +            // Split on first { and take everything after it
-+            const jsonPart = $output[0].split('{', 2);
-+            if (jsonPart.length < 2) {
++            $jsonParts = explode('{', $output[0], 2);
++            if (count($jsonParts) < 2) {
 +                my_logger("SSO Login Attempt Failed: No JSON found in response");
 +                return false;
 +            }
-+            $response = json_decode('{' + $jsonPart[1], true);
++            $response = json_decode('{' . $jsonParts[1], true);
 +            if (isset($response['valid']) && $response['valid'] === true) {
 +                return true;
 +            }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
@@ -12,7 +12,7 @@ export default class SSOFileModification extends FileModification {
     protected async generatePatch(overridePath?: string): Promise<string> {
         // Define the new PHP function to insert
         /* eslint-disable no-useless-escape */
-        const newFunction = /** PHP */`
+        const newFunction = /** PHP */ `
 function verifyUsernamePasswordAndSSO(string $username, string $password): bool {
     if ($username != "root") return false;
 

--- a/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
@@ -45,7 +45,13 @@ function verifyUsernamePasswordAndSSO(string $username, string $password): bool 
         }
 
         try {
-            $response = json_decode($output[0], true);
+            // Split on first { and take everything after it
+            const jsonPart = $output[0].split('{', 2);
+            if (jsonPart.length < 2) {
+                my_logger("SSO Login Attempt Failed: No JSON found in response");
+                return false;
+            }
+            $response = json_decode('{' + $jsonPart[1], true);
             if (isset($response['valid']) && $response['valid'] === true) {
                 return true;
             }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
@@ -12,7 +12,7 @@ export default class SSOFileModification extends FileModification {
     protected async generatePatch(overridePath?: string): Promise<string> {
         // Define the new PHP function to insert
         /* eslint-disable no-useless-escape */
-        const newFunction = `
+        const newFunction = /** PHP */`
 function verifyUsernamePasswordAndSSO(string $username, string $password): bool {
     if ($username != "root") return false;
 
@@ -46,12 +46,12 @@ function verifyUsernamePasswordAndSSO(string $username, string $password): bool 
 
         try {
             // Split on first { and take everything after it
-            const jsonPart = $output[0].split('{', 2);
-            if (jsonPart.length < 2) {
+            $jsonParts = explode('{', $output[0], 2);
+            if (count($jsonParts) < 2) {
                 my_logger("SSO Login Attempt Failed: No JSON found in response");
                 return false;
             }
-            $response = json_decode('{' + $jsonPart[1], true);
+            $response = json_decode('{' . $jsonParts[1], true);
             if (isset($response['valid']) && $response['valid'] === true) {
                 return true;
             }


### PR DESCRIPTION
@pujitm This broke with the plugins service. Rather than fix the logging, I decided to fix the parser to be more permissive. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the SSO login process by improving the handling of response data. This update increases reliability when unexpected response formats occur during authentication.
- **New Features**
	- Introduced a new function for validating user credentials and SSO tokens, enhancing the login functionality with improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->