### PR TITLE
fix: rc.unraid-api now cleans up older dependencies

### DIFF
--- a/plugin/source/dynamix.unraid.net/etc/rc.d/rc.unraid-api
+++ b/plugin/source/dynamix.unraid.net/etc/rc.d/rc.unraid-api
@@ -111,7 +111,18 @@ case "$1" in
   ;;
 'ensure')
   if [ -x "$scripts_dir/dependencies.sh" ]; then
+    # First clean up old dependencies
+    "$scripts_dir/dependencies.sh" cleanup
+    # Then ensure new dependencies are installed
     "$scripts_dir/dependencies.sh" ensure "$2"
+  else
+    echo "Error: dependencies.sh script not found or not executable"
+    exit 1
+  fi
+  ;;
+'cleanup-dependencies')
+  if [ -x "$scripts_dir/dependencies.sh" ]; then
+    "$scripts_dir/dependencies.sh" cleanup
   else
     echo "Error: dependencies.sh script not found or not executable"
     exit 1

--- a/plugin/source/dynamix.unraid.net/usr/local/share/dynamix.unraid.net/install/scripts/setup_api.sh
+++ b/plugin/source/dynamix.unraid.net/usr/local/share/dynamix.unraid.net/install/scripts/setup_api.sh
@@ -69,19 +69,6 @@ else
   echo "ERROR: .env.production file not found"
 fi
 
-# Restore dependencies using vendor archive from package
-if [ -x "/etc/rc.d/rc.unraid-api" ]; then
-  echo "Restoring dependencies using auto-detection"
-  if /etc/rc.d/rc.unraid-api ensure; then
-    echo "Dependencies restored successfully"
-  else
-    echo "ERROR: Failed to restore dependencies" >&2
-    exit 1
-  fi
-else
-  echo "Dependencies not restored: rc.unraid-api executable not found"
-fi
-
 # Ensure rc directories exist and scripts are executable
 echo "Ensuring shutdown scripts are executable"
 if [ -d "/etc/rc.d/rc6.d" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to clean up old dependency files, keeping only those needed for the current API version.
  - Introduced a direct cleanup command to remove outdated dependencies before installing new ones.

- **Bug Fixes**
  - Improved handling and messaging for missing or invalid dependency information during cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->