### PR TITLE
fix: node_modules dir removed on plugin update

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -235,6 +235,13 @@ for txz_file in /boot/config/plugins/dynamix.my.servers/dynamix.unraid.net-*.txz
   fi
 done
 
+# Remove existing node_modules directory
+echo "Cleaning up existing node_modules directory..."
+if [ -d "/usr/local/unraid-api/node_modules" ]; then
+  echo "Removing: /usr/local/unraid-api/node_modules"
+  rm -rf "/usr/local/unraid-api/node_modules"
+fi
+
 # Install the package using the explicit file path
 upgradepkg --install-new --reinstall "${PKG_FILE}"
 if [ $? -ne 0 ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved installation process by automatically cleaning up old package directories before installing or upgrading the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->