### PR TITLE
fix: api `pnpm type-check`

### DIFF
--- a/api/src/unraid-api/graph/resolvers/api-key/api-key.model.ts
+++ b/api/src/unraid-api/graph/resolvers/api-key/api-key.model.ts
@@ -114,7 +114,7 @@ export class CreateApiKeyInput {
     @AtLeastOneOf(['roles', 'permissions'], {
         message: 'At least one role or one permission is required to create an API key.',
     })
-    _atLeastOne!: boolean;
+    _atLeastOne?: boolean;
 }
 
 @InputType()
@@ -149,7 +149,7 @@ export class UpdateApiKeyInput {
     @AtLeastOneOf(['roles', 'permissions'], {
         message: 'At least one role or one permission is required to update an API key.',
     })
-    _atLeastOne!: boolean;
+    _atLeastOne?: boolean;
 }
 
 @InputType()

--- a/api/src/unraid-api/graph/resolvers/api-key/api-key.mutation.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/api-key/api-key.mutation.spec.ts
@@ -59,7 +59,6 @@ describe('ApiKeyMutationsResolver', () => {
                 description: 'New API Key Description',
                 roles: [Role.GUEST],
                 permissions: [],
-                _atLeastOne: undefined,
             };
 
             vi.spyOn(apiKeyService, 'create').mockResolvedValue(mockApiKeyWithSecret);
@@ -84,7 +83,6 @@ describe('ApiKeyMutationsResolver', () => {
                 description: 'Should fail',
                 roles: [Role.GUEST],
                 permissions: [],
-                _atLeastOne: undefined,
             };
             vi.spyOn(apiKeyService, 'create').mockRejectedValue(new Error('Create failed'));
             await expect(resolver.create(input)).rejects.toThrow('Create failed');
@@ -96,7 +94,6 @@ describe('ApiKeyMutationsResolver', () => {
                 description: 'Should fail sync',
                 roles: [Role.GUEST],
                 permissions: [],
-                _atLeastOne: undefined,
             };
             vi.spyOn(apiKeyService, 'create').mockResolvedValue(mockApiKeyWithSecret);
             vi.spyOn(authService, 'syncApiKeyRoles').mockRejectedValue(new Error('Sync failed'));
@@ -109,7 +106,6 @@ describe('ApiKeyMutationsResolver', () => {
                 description: 'No name',
                 roles: [Role.GUEST],
                 permissions: [],
-                _atLeastOne: undefined,
             };
             await expect(resolver.create(input)).rejects.toThrow();
         });

--- a/api/src/unraid-api/main.ts
+++ b/api/src/unraid-api/main.ts
@@ -35,9 +35,22 @@ export async function bootstrapNestServer(): Promise<NestFastifyApplication> {
 
     const server = app.getHttpAdapter().getInstance();
 
+    /**------------------------------------------------------------------------
+     * !                       Fastify Type Compatibility
+     *
+     * There are known type issues with fastify plugin registration in nestjs.
+     * These don't affect runtime functionality, but will cause type errors.
+     *
+     * See: https://github.com/nestjs/nest/issues/13219
+     *
+     * tl;dr different types used by nestjs/platform-fastify and fastify.
+     *------------------------------------------------------------------------**/
+
+    // @ts-expect-error - Known nestjs x fastify type compatibility issue
     await server.register(fastifyCookie);
 
     // Minimal Helmet configuration to avoid blocking plugin functionality
+    // @ts-expect-error - Known nestjs x fastify type compatibility issue
     await server.register(fastifyHelmet, {
         // Disable restrictive policies
         contentSecurityPolicy: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests for API key creation by removing unnecessary properties from input objects.

* **Documentation**
  * Added detailed comments explaining type compatibility issues and error suppression for Fastify plugins.

* **Refactor**
  * Made internal validation flags optional in API key input handling to streamline input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->