### PR TITLE
fix(ui): notifications positioning regression

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
@@ -10,7 +10,7 @@ export default class DefaultPageLayoutModification extends FileModification {
     public readonly filePath: string = '/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php';
 
     private addToaster(source: string): string {
-        if (source.includes('unraid-toaster')) {
+        if (source.includes('uui-toaster')) {
             return source;
         }
         const insertion = `<uui-toaster rich-colors close-button position="<?= ($notify['position'] === 'center') ? 'top-center' : $notify['position'] ?>"></uui-toaster>`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,8 +839,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       vue-sonner:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^1.3.0
+        version: 1.3.0
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.1
@@ -11107,7 +11107,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -13116,8 +13115,8 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
-  vue-sonner@2.0.1:
-    resolution: {integrity: sha512-sn4vjCRzRcnMaxaLa9aNSyZQi6S+gshiea5Lc3eqpkj0ES9LH8ljg+WJCkxefr28V4PZ9xkUXBIWpxGfQxstIg==}
+  vue-sonner@1.3.0:
+    resolution: {integrity: sha512-jAodBy4Mri8rQjVZGQAPs4ZYymc1ywPiwfa81qU0fFl+Suk7U8NaOxIDdI1oBGLeQJqRZi/oxNIuhCLqsBmOwg==}
 
   vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
@@ -27305,7 +27304,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.17(typescript@5.8.3)
 
-  vue-sonner@2.0.1: {}
+  vue-sonner@1.3.0: {}
 
   vue-template-compiler@2.7.16:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,8 +839,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       vue-sonner:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.1
@@ -13116,8 +13116,8 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
-  vue-sonner@2.0.0:
-    resolution: {integrity: sha512-nvlqGGWvxEv9UnKcZxsGdKpHrODEdv3CXAJF3er+1pLC03caJt2+v9HuWtRqlBQwUr1SFttsYuwVbpbEl05n4A==}
+  vue-sonner@2.0.1:
+    resolution: {integrity: sha512-sn4vjCRzRcnMaxaLa9aNSyZQi6S+gshiea5Lc3eqpkj0ES9LH8ljg+WJCkxefr28V4PZ9xkUXBIWpxGfQxstIg==}
 
   vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
@@ -27305,7 +27305,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.17(typescript@5.8.3)
 
-  vue-sonner@2.0.0: {}
+  vue-sonner@2.0.1: {}
 
   vue-template-compiler@2.7.16:
     dependencies:

--- a/unraid-ui/package.json
+++ b/unraid-ui/package.json
@@ -61,7 +61,7 @@
     "marked": "^15.0.0",
     "reka-ui": "^2.1.1",
     "tailwind-merge": "^2.6.0",
-    "vue-sonner": "^2.0.1"
+    "vue-sonner": "^1.3.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",

--- a/unraid-ui/package.json
+++ b/unraid-ui/package.json
@@ -61,7 +61,7 @@
     "marked": "^15.0.0",
     "reka-ui": "^2.1.1",
     "tailwind-merge": "^2.6.0",
-    "vue-sonner": "^2.0.0"
+    "vue-sonner": "^2.0.1"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",


### PR DESCRIPTION
Downgrades the `vue-sonner` dependency from `2.0.0` to `1.3.0` because the newer version relies on unocss under the hood, which can't pipe across the web component build/boundary without modifying our css plumbing.

The older version relied on a `styles.css` stylesheet. That stylesheet also couldn't make it through our build pipeline, but since it was a single asset, I vendored it via `sonner.css`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logic to prevent duplicate insertion of the toaster element in the page layout.

* **Chores**
  * Downgraded the "vue-sonner" dependency to version ^1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210640791480730