### PR TITLE
build: fix artifact retreival in plugin promotion workflow

### DIFF
--- a/.github/workflows/push-staging-pr-on-close.yml
+++ b/.github/workflows/push-staging-pr-on-close.yml
@@ -65,7 +65,7 @@ jobs:
                 
           # Change the plugin url to point to staging
           url="https://preview.dl.unraid.net/unraid-api/dynamix.unraid.net.plg"
-          sed -i -E "s#(<!ENTITY pluginURL \").*(\">)#\1${url}\2#g" "${plgfile}" || exit 1
+          sed -i -E "s#(<!ENTITY plugin_url \").*?(\">)#\1${url}\2#g" "${plgfile}" || exit 1
           cat "${plgfile}"
           mkdir -p pr-release
           mv "${plgfile}" pr-release/dynamix.unraid.net.plg

--- a/.github/workflows/push-staging-pr-on-close.yml
+++ b/.github/workflows/push-staging-pr-on-close.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to test with'
+        description: "PR number to test with"
         required: true
         type: string
       pr_merged:
-        description: 'Simulate merged PR'
+        description: "Simulate merged PR"
         required: true
         type: boolean
         default: true
@@ -37,6 +37,18 @@ jobs:
             echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Debug PR info
+        run: |
+          echo "PR Number: ${{ steps.pr_number.outputs.pr_number }}"
+          echo "Event name: ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "PR merged: ${{ github.event.pull_request.merged }}"
+          fi
+
+          echo "Listing artifacts for PR ${{ steps.pr_number.outputs.pr_number }}:"
+          gh api repos/${{ github.repository }}/actions/artifacts --paginate | \
+            jq -r '.artifacts[] | select(.workflow_run.head_branch == "pr/${{ steps.pr_number.outputs.pr_number }}") | "  - \(.name) (run: \(.workflow_run.id))"' || echo "No artifacts found or error listing artifacts"
+
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v11
         with:
@@ -55,7 +67,7 @@ jobs:
             ls -la connect-files/
             exit 1
           fi
-          
+
           echo "Found plugin file: $plgfile"
           version=$(date +"%Y.%m.%d.%H%M")
           sed -i -E "s#(<!ENTITY version \").*(\">)#\1${version}\2#g" "${plgfile}" || exit 1

--- a/.github/workflows/push-staging-pr-on-close.yml
+++ b/.github/workflows/push-staging-pr-on-close.yml
@@ -38,6 +38,8 @@ jobs:
           fi
 
       - name: Debug PR info
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "PR Number: ${{ steps.pr_number.outputs.pr_number }}"
           echo "Event name: ${{ github.event_name }}"
@@ -46,8 +48,10 @@ jobs:
           fi
 
           echo "Listing artifacts for PR ${{ steps.pr_number.outputs.pr_number }}:"
-          gh api repos/${{ github.repository }}/actions/artifacts --paginate | \
-            jq -r '.artifacts[] | select(.workflow_run.head_branch == "pr/${{ steps.pr_number.outputs.pr_number }}") | "  - \(.name) (run: \(.workflow_run.id))"' || echo "No artifacts found or error listing artifacts"
+          pr_branch="pr/${{ steps.pr_number.outputs.pr_number }}"
+          for run_id in $(gh api repos/${{ github.repository }}/actions/runs -F branch=${pr_branch} --paginate -q '.workflow_runs[].id'); do
+            gh api repos/${{ github.repository }}/actions/runs/${run_id}/artifacts -q '.artifacts[].name' | sed "s/^/  - /"
+          done || echo "No artifacts found for branch ${pr_branch} or error listing artifacts"
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v11

--- a/.github/workflows/push-staging-pr-on-close.yml
+++ b/.github/workflows/push-staging-pr-on-close.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     steps:
       - name: Set Timezone
         uses: szenius/set-timezone@v2.0
@@ -61,6 +62,8 @@ jobs:
           path: connect-files
           pr: ${{ steps.pr_number.outputs.pr_number }}
           workflow_conclusion: success
+          workflow_search: true
+          search_artifacts: true
 
       - name: Update Downloaded Staging Plugin to New Date
         run: |

--- a/.github/workflows/push-staging-pr-on-close.yml
+++ b/.github/workflows/push-staging-pr-on-close.yml
@@ -38,22 +38,6 @@ jobs:
             echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Debug PR info
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "PR Number: ${{ steps.pr_number.outputs.pr_number }}"
-          echo "Event name: ${{ github.event_name }}"
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "PR merged: ${{ github.event.pull_request.merged }}"
-          fi
-
-          echo "Listing artifacts for PR ${{ steps.pr_number.outputs.pr_number }}:"
-          pr_branch="pr/${{ steps.pr_number.outputs.pr_number }}"
-          for run_id in $(gh api repos/${{ github.repository }}/actions/runs -F branch=${pr_branch} --paginate -q '.workflow_runs[].id'); do
-            gh api repos/${{ github.repository }}/actions/runs/${run_id}/artifacts -q '.artifacts[].name' | sed "s/^/  - /"
-          done || echo "No artifacts found for branch ${pr_branch} or error listing artifacts"
-
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v11
         with:


### PR DESCRIPTION
Tested via manual dispatch on #1456 via cli. results in:
```xml
<!DOCTYPE PLUGIN [
  <!ENTITY name "dynamix.unraid.net">
  <!ENTITY launch "Connect">
  <!ENTITY author "limetech">
  <!ENTITY version "2025.07.03.0623">
  <!ENTITY plugin_url "https://preview.dl.unraid.net/unraid-api/dynamix.unraid.net.plg">
  <!ENTITY source "/boot/config/plugins/dynamix.my.servers/&txz_name;">
  <!ENTITY txz_sha256 "2075cdb8206733f7f037fefdb004a2d719498d6d6d7f3872afd0682a40ceff28">
  <!ENTITY txz_url "https://preview.dl.unraid.net/unraid-api/tag/PR1456/dynamix.unraid.net-4.8.0-x86_64-24.txz">
  <!ENTITY txz_name "dynamix.unraid.net-4.8.0-x86_64-24.txz">
  <!ENTITY arch "x86_64">
  <!ENTITY build "24">
  <!ENTITY tag "PR1456">
  <!ENTITY api_version "4.8.0">
]>
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow input descriptions for consistency.
  * Expanded job permissions to improve workflow capabilities.
  * Enhanced artifact download step with additional input options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->