### PR TITLE
chore: inform users to refresh page if nchan breaks

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -306,6 +306,7 @@ echo "Installation completed at $(date)" >> "$LOGFILE"
 /etc/rc.d/rc.unraid-api cleanup-dependencies
 
 echo "Starting Unraid API service"
+echo "If no additional messages appear within 30 seconds, it is safe to refresh the page."
 /etc/rc.d/rc.unraid-api plugins add unraid-api-plugin-connect -b --no-restart
 /etc/rc.d/rc.unraid-api start
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational message during plugin installation to guide users on when it is safe to refresh the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->