### PR TITLE
fix: duplicated header logo after api stops

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/DefaultPageLayout.php.modified.snapshot.php
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/__test__/snapshots/DefaultPageLayout.php.modified.snapshot.php
@@ -711,7 +711,7 @@ $.ajaxPrefilter(function(s, orig, xhr){
   <div class="upgrade_notice" style="display:none"></div>
   <div id="header" class="<?=$display['banner']?>">
     <div class="logo">
-      
+      <a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>
       <unraid-i18n-host><unraid-header-os-version></unraid-header-os-version></unraid-i18n-host>
     </div>
     <?include "$docroot/plugins/dynamix.my.servers/include/myservers2.php"?>

--- a/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
@@ -65,13 +65,6 @@ if (is_localhost() && !is_good_session()) {
         return this.prependDoctypeWithPhp(source, newPhpCode);
     }
 
-    private hideHeaderLogo(source: string): string {
-        return source.replace(
-            '<a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>',
-            ''
-        );
-    }
-
     private addModalsWebComponent(source: string): string {
         return source.replace('<body>', '<body>\n<unraid-modals></unraid-modals>');
     }
@@ -81,7 +74,6 @@ if (is_localhost() && !is_good_session()) {
             this.replaceToasts.bind(this),
             this.addToaster.bind(this),
             this.patchGuiBootAuth.bind(this),
-            this.hideHeaderLogo.bind(this),
             this.addModalsWebComponent.bind(this),
         ];
 

--- a/api/src/unraid-api/unraid-file-modifier/modifications/patches/default-page-layout.patch
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/patches/default-page-layout.patch
@@ -53,7 +53,7 @@ Index: /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php
  }
  
  function closeNotifier() {
-@@ -695,15 +704,16 @@
+@@ -695,10 +704,11 @@
  });
  </script>
  <?include "$docroot/plugins/dynamix.my.servers/include/myservers1.php"?>
@@ -64,13 +64,7 @@ Index: /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php
    <div class="upgrade_notice" style="display:none"></div>
    <div id="header" class="<?=$display['banner']?>">
      <div class="logo">
--      <a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>
-+      
-       <unraid-i18n-host><unraid-header-os-version></unraid-header-os-version></unraid-i18n-host>
-     </div>
-     <?include "$docroot/plugins/dynamix.my.servers/include/myservers2.php"?>
-   </div>
-   <a href="#" class="move_to_end" title="<?=_('Move To End')?>"><i class="fa fa-arrow-circle-down"></i></a>
+       <a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>
 @@ -748,12 +758,12 @@
    }
    // create list of nchan scripts to be started

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -141,11 +141,19 @@ exit 0
   <FILE Run="/bin/bash" Method="install">
     <INLINE>
       <![CDATA[
-      echo "Patching header logo..."
+      echo "Patching header logo if necessary..."
+
+      # We do this here instead of via API FileModification to avoid undesirable
+      # rollback when the API is stopped.
+      #
+      # This is necessary on < 7.2 because the unraid-header-os-version web component
+      # that ships with the base OS only displayes the version, not the logo as well.
+      #
+      # Rolling back in this case (i.e when stopping the API) yields a duplicate logo
+      # that blocks interaction with the navigation menu.
       
-      # Remove the old header logo from DefaultPageLayout.php
+      # Remove the old header logo from DefaultPageLayout.php if present
       if [ -f "/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php" ]; then
-        echo "Removing old header logo from DefaultPageLayout.php..."
         sed -i 's|<a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>||g' "/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php"
       fi
 

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -138,6 +138,21 @@ exit 0
     </INLINE>
   </FILE>
 
+  <FILE Run="/bin/bash" Method="install">
+    <INLINE>
+      <![CDATA[
+      echo "Patching header logo..."
+      
+      # Remove the old header logo from DefaultPageLayout.php
+      if [ -f "/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php" ]; then
+        echo "Removing old header logo from DefaultPageLayout.php..."
+        sed -i 's|<a href="https://unraid.net" target="_blank"><?readfile("$docroot/webGui/images/UN-logotype-gradient.svg")?></a>||g' "/usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php"
+      fi
+
+      ]]>
+    </INLINE>
+  </FILE>
+
   <FILE Run="/bin/bash" Method="remove">
     <INLINE>
       MAINNAME="&name;"


### PR DESCRIPTION
Move legacy header logo omission from API file modifier to plg install step to avoid breaking rollback (ie upon `unraid-api stop`) due to web component upgrade.

Tested on 7.1.4 & 7.2.0-beta.0.16

Testing & Reproduction procedure:

1. Install connect plugin
2. Run `unraid-api stop` on server
3. Refresh page. Before Unraid 7.2, Plugin versions prior to this will display a duplicated logo that blocks the nav menu. Now, it will not. Plugin uninstall behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The plugin installation process now updates the header logo by removing the old logo from the interface during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->