### PR TITLE
fix(connect): omit extraneous fields during connect config validation

### DIFF
--- a/api/dev/configs/connect.json
+++ b/api/dev/configs/connect.json
@@ -2,18 +2,11 @@
   "wanaccess": true,
   "wanport": 8443,
   "upnpEnabled": false,
-  "apikey": "test-api-key-12345",
+  "apikey": "_______________________BIG_API_KEY_HERE_________________________",
   "localApiKey": "_______________________LOCAL_API_KEY_HERE_________________________",
   "email": "test@example.com",
   "username": "zspearmint",
   "avatar": "https://via.placeholder.com/200",
   "regWizTime": "1611175408732_0951-1653-3509-FBA155FA23C0",
-  "dynamicRemoteAccessType": "DISABLED",
-  "version": "4.4.1",
-  "extraOrigins": "https://google.com,https://test.com",
-  "sandbox": "yes",
-  "accesstoken": "",
-  "idtoken": "",
-  "refreshtoken": "",
-  "ssoSubIds": []
+  "dynamicRemoteAccessType": "DISABLED"
 }

--- a/packages/unraid-api-plugin-connect/src/config/config.persistence.ts
+++ b/packages/unraid-api-plugin-connect/src/config/config.persistence.ts
@@ -55,7 +55,7 @@ export class ConnectConfigPersister extends ConfigFilePersister<MyServersConfig>
                 enableImplicitConversion: true,
             });
         }
-        await validateOrReject(instance);
+        await validateOrReject(instance, { whitelist: true });
         return instance;
     }
 


### PR DESCRIPTION
Prevent extraneous fields from migrating to `connect.json` from `myservers.cfg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file to remove unused fields and replace the API key placeholder with a more generic string.

* **Refactor**
  * Improved configuration validation to automatically remove any unrecognized properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->