### PR TITLE
fix(connect): remove unraid-api folder before creating symlink

### DIFF
--- a/plugin/source/dynamix.unraid.net/install/doinst.sh
+++ b/plugin/source/dynamix.unraid.net/install/doinst.sh
@@ -13,7 +13,7 @@ done
 chmod +x usr/local/unraid-api/dist/cli.js
 chmod +x usr/local/unraid-api/dist/main.js
 
-rm -f usr/local/bin/unraid-api
+rm -rf usr/local/bin/unraid-api
 ln -sf ../unraid-api/dist/cli.js usr/local/bin/unraid-api
 # deprecated
 ln -sf ../bin/unraid-api usr/local/sbin/unraid-api


### PR DESCRIPTION
During plugin installation, if `/usr/local/bin/unraid-api` exists as a directory, the installation fails because `rm -f` cannot remove a directory. This change replaces `rm -f` with `rm -rf` to ensure that the path is removed regardless of whether it is a file or a directory, allowing the symlink to be created successfully.