### PR TITLE
fix: change config file loading error log to debug

### DIFF
--- a/packages/unraid-shared/src/util/config-file-handler.ts
+++ b/packages/unraid-shared/src/util/config-file-handler.ts
@@ -59,7 +59,7 @@ export class ConfigFileHandler<T extends object> {
         ...fileConfig,
       });
     } catch (error) {
-      this.logger.warn(error, "Error loading config. Attempting to migrate...");
+      this.logger.debug(error, "Error loading config. Attempting to migrate...");
 
       try {
         const migratedConfig = await this.definition.migrateConfig();


### PR DESCRIPTION
To reduce noise and a false-negative syslog upon a user's first boot. this way, we can opt into the trace if there's an issue.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210958709343109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted logging for configuration file loading errors to reduce log verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->