### PR TITLE
refactor: mv `7.2.0` version check to file modifier super class

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/file-modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/file-modification.ts
@@ -214,6 +214,13 @@ export abstract class FileModification {
     // Default implementation that can be overridden if needed
     async shouldApply(): Promise<ShouldApplyWithReason> {
         try {
+            if (await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0')) {
+                return {
+                    shouldApply: false,
+                    reason: 'Patch unnecessary for Unraid 7.2 or later because the Unraid API is integrated.',
+                };
+            }
+
             if (!this.filePath || !this.id) {
                 throw new Error('Invalid file modification configuration');
             }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/auth-request.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/auth-request.modification.ts
@@ -62,17 +62,4 @@ export default class AuthRequestModification extends FileModification {
 
         return this.createPatchWithDiff(overridePath ?? this.filePath, fileContent, newContent);
     }
-
-    async shouldApply(): Promise<ShouldApplyWithReason> {
-        if (await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0')) {
-            return {
-                shouldApply: false,
-                reason: 'Skipping for Unraid 7.2 or later, where the Unraid API is integrated.',
-            };
-        }
-        return {
-            shouldApply: true,
-            reason: 'Unraid version is less than 7.2.0, applying the patch.',
-        };
-    }
 }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/default-page-layout.modification.ts
@@ -99,21 +99,4 @@ if (is_localhost() && !is_good_session()) {
 
         return this.createPatchWithDiff(overridePath ?? this.filePath, fileContent, newContent);
     }
-
-    async shouldApply(): Promise<ShouldApplyWithReason> {
-        // Check if system is running Unraid 7.2 or later, where the Unraid API is integrated
-        const isUnraidVersionGreaterThanOrEqualTo72 =
-            await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0');
-        if (isUnraidVersionGreaterThanOrEqualTo72) {
-            return {
-                shouldApply: false,
-                reason: 'Skipping for Unraid 7.2 or later, where the Unraid API is integrated.',
-            };
-        }
-
-        return {
-            shouldApply: true,
-            reason: 'Always apply the allowed file changes to ensure compatibility.',
-        };
-    }
 }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/notifications-page.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/notifications-page.modification.ts
@@ -17,19 +17,6 @@ export default class NotificationsPageModification extends FileModification {
         return this.createPatchWithDiff(overridePath ?? this.filePath, fileContent, newContent);
     }
 
-    async shouldApply(): Promise<ShouldApplyWithReason> {
-        if (await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0')) {
-            return {
-                shouldApply: false,
-                reason: 'Skipping for Unraid 7.2 or later, where the Unraid API is integrated.',
-            };
-        }
-        return {
-            shouldApply: true,
-            reason: 'Always apply the allowed file changes to ensure compatibility.',
-        };
-    }
-
     private static applyToSource(fileContent: string): string {
         return (
             fileContent

--- a/api/src/unraid-api/unraid-file-modifier/modifications/rc-nginx.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/rc-nginx.modification.ts
@@ -91,16 +91,10 @@ check_remote_access(){
     }
 
     async shouldApply(): Promise<ShouldApplyWithReason> {
-        if (await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0')) {
-            return {
-                shouldApply: false,
-                reason: 'Patch unnecessary for Unraid 7.2 or later because the Unraid API is integrated.',
-            };
-        }
         const { shouldApply, reason } = await super.shouldApply();
         return {
-            shouldApply: shouldApply,
-            reason: shouldApply ? 'Unraid version is less than 7.2.0, applying the patch.' : reason,
+            shouldApply,
+            reason,
             effects: ['nginx:reload'],
         };
     }

--- a/api/src/unraid-api/unraid-file-modifier/modifications/set-password-modal.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/set-password-modal.modification.ts
@@ -19,11 +19,9 @@ export default class SetPasswordModalModification extends FileModification {
     }
 
     async shouldApply(): Promise<ShouldApplyWithReason> {
-        if (await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0')) {
-            return {
-                shouldApply: false,
-                reason: 'Skipping for Unraid 7.2 or later, where the Unraid API is integrated.',
-            };
+        const superShouldApply = await super.shouldApply();
+        if (!superShouldApply.shouldApply) {
+            return superShouldApply;
         }
         const fileContent = await readFile(this.filePath, 'utf-8');
         const injectString =

--- a/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/sso.modification.ts
@@ -89,13 +89,9 @@ function verifyUsernamePasswordAndSSO(string $username, string $password): bool 
     }
 
     async shouldApply(): Promise<ShouldApplyWithReason> {
-        const isUnraidVersionGreaterThanOrEqualTo72 =
-            await this.isUnraidVersionGreaterThanOrEqualTo('7.2.0');
-        if (isUnraidVersionGreaterThanOrEqualTo72) {
-            return {
-                shouldApply: false,
-                reason: 'Skipping for Unraid 7.2 or later, where the Unraid API is integrated.',
-            };
+        const superShouldApply = await super.shouldApply();
+        if (!superShouldApply.shouldApply) {
+            return superShouldApply;
         }
 
         if (!this.configService) {

--- a/api/src/unraid-api/unraid-file-modifier/unraid-file-modifier.service.ts
+++ b/api/src/unraid-api/unraid-file-modifier/unraid-file-modifier.service.ts
@@ -124,7 +124,7 @@ export class UnraidFileModificationService
                 shouldApplyWithReason.effects?.forEach((effect) => this.effects.add(effect));
                 this.logger.log(`Modification applied successfully: ${modification.id}`);
             } else {
-                this.logger.log(
+                this.logger.debug(
                     `Skipping modification: ${modification.id} - ${shouldApplyWithReason.reason}`
                 );
             }


### PR DESCRIPTION
## Summary by CodeRabbit

* **Bug Fixes**
  * `nginx:reload` effect is no longer triggered via the nginx.conf modification on 7.2.0.
  * Improved consistency in determining when patches and modifications should be applied for Unraid versions 7.2.0 and above.
  * Removed redundant version checks from several modification modules to streamline patch application logic.
  * Adjusted logging for skipped modifications to reduce output verbosity.

* **Refactor**
  * Centralized version-based logic for patch application, reducing duplication and improving maintainability.