### PR TITLE
Authentik SSO Instruction Clarity

### DIFF
--- a/api/docs/public/oidc-provider-setup.md
+++ b/api/docs/public/oidc-provider-setup.md
@@ -397,7 +397,7 @@ Create a new OAuth2/OpenID Provider in Authentik, then create an Application and
 
 **Configuration:**
 
-- **Issuer URL**: `https://authentik.example.com/application/o/unraid-api/`
+- **Issuer URL**: `https://authentik.example.com/application/o/<application_slug>/`
 - **Client ID**: From Authentik provider configuration
 - **Client Secret**: From Authentik provider configuration
 - **Required Scopes**: `openid`, `profile`, `email`


### PR DESCRIPTION
Change hard coded application slug to <application_slug> to show this needs to be changed to match others (IE https://integrations.goauthentik.io/infrastructure/semaphore/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OIDC provider setup guide: Authentik configuration now shows a placeholder Issuer URL with a dynamic application slug instead of a fixed path. Clarifies how to configure per-application Issuer URLs and reduces setup confusion. No functional changes; guidance only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->