### PR TITLE
feat(api): restructure versioning information in GraphQL schema

### DIFF
--- a/api/dev/configs/api.json
+++ b/api/dev/configs/api.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.13.1",
+  "version": "4.14.0",
   "extraOrigins": [],
   "sandbox": true,
   "ssoSubIds": [],

--- a/api/generated-schema.graphql
+++ b/api/generated-schema.graphql
@@ -1501,12 +1501,18 @@ type InfoBaseboard implements Node {
   memSlots: Float
 }
 
-type InfoVersions implements Node {
-  id: PrefixedID!
+type CoreVersions {
+  """Unraid version"""
+  unraid: String
+
+  """Unraid API version"""
+  api: String
 
   """Kernel version"""
   kernel: String
+}
 
+type PackageVersions {
   """OpenSSL version"""
   openssl: String
 
@@ -1590,9 +1596,16 @@ type InfoVersions implements Node {
 
   """Docker version"""
   docker: String
+}
 
-  """Unraid version"""
-  unraid: String
+type InfoVersions implements Node {
+  id: PrefixedID!
+
+  """Core system versions"""
+  core: CoreVersions!
+
+  """Software package versions"""
+  packages: PackageVersions!
 }
 
 type Info implements Node {

--- a/api/src/unraid-api/cli/generated/graphql.ts
+++ b/api/src/unraid-api/cli/generated/graphql.ts
@@ -1041,6 +1041,8 @@ export type InfoVersions = Node & {
   __typename?: 'InfoVersions';
   /** Apache version */
   apache?: Maybe<Scalars['String']['output']>;
+  /** Unraid API version */
+  api?: Maybe<Scalars['String']['output']>;
   /** Docker version */
   docker?: Maybe<Scalars['String']['output']>;
   /** gcc version */

--- a/api/src/unraid-api/graph/resolvers/info/info.module.ts
+++ b/api/src/unraid-api/graph/resolvers/info/info.module.ts
@@ -8,6 +8,8 @@ import { DisplayService } from '@app/unraid-api/graph/resolvers/info/display/dis
 import { InfoResolver } from '@app/unraid-api/graph/resolvers/info/info.resolver.js';
 import { MemoryService } from '@app/unraid-api/graph/resolvers/info/memory/memory.service.js';
 import { OsService } from '@app/unraid-api/graph/resolvers/info/os/os.service.js';
+import { CoreVersionsResolver } from '@app/unraid-api/graph/resolvers/info/versions/core-versions.resolver.js';
+import { VersionsResolver } from '@app/unraid-api/graph/resolvers/info/versions/versions.resolver.js';
 import { VersionsService } from '@app/unraid-api/graph/resolvers/info/versions/versions.service.js';
 import { ServicesModule } from '@app/unraid-api/graph/services/services.module.js';
 
@@ -19,6 +21,8 @@ import { ServicesModule } from '@app/unraid-api/graph/services/services.module.j
 
         // Sub-resolvers
         DevicesResolver,
+        VersionsResolver,
+        CoreVersionsResolver,
 
         // Services
         CpuService,
@@ -28,6 +32,6 @@ import { ServicesModule } from '@app/unraid-api/graph/services/services.module.j
         VersionsService,
         DisplayService,
     ],
-    exports: [InfoResolver, DevicesResolver, DisplayService],
+    exports: [InfoResolver, DevicesResolver, VersionsResolver, CoreVersionsResolver, DisplayService],
 })
 export class InfoModule {}

--- a/api/src/unraid-api/graph/resolvers/info/info.resolver.integration.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/info/info.resolver.integration.spec.ts
@@ -169,12 +169,7 @@ describe('InfoResolver Integration Tests', () => {
             const result = await infoResolver.versions();
 
             expect(result).toHaveProperty('id', 'info/versions');
-            expect(result).toHaveProperty('unraid');
-            expect(result).toHaveProperty('kernel');
-            expect(result).toHaveProperty('node');
-            expect(result).toHaveProperty('npm');
-            // Verify unraid version from mock
-            expect(result.unraid).toBe('6.12.0');
+            // Versions now returns a stub object, with actual data resolved via field resolvers
         });
     });
 

--- a/api/src/unraid-api/graph/resolvers/info/info.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/info/info.resolver.ts
@@ -94,7 +94,7 @@ export class InfoResolver {
     }
 
     @ResolveField(() => InfoVersions)
-    public async versions(): Promise<InfoVersions> {
+    public versions(): Partial<InfoVersions> {
         return this.versionsService.generateVersions();
     }
 }

--- a/api/src/unraid-api/graph/resolvers/info/versions/core-versions.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/info/versions/core-versions.resolver.ts
@@ -1,0 +1,14 @@
+import { ResolveField, Resolver } from '@nestjs/graphql';
+
+import { versions } from 'systeminformation';
+
+import { CoreVersions } from '@app/unraid-api/graph/resolvers/info/versions/versions.model.js';
+
+@Resolver(() => CoreVersions)
+export class CoreVersionsResolver {
+    @ResolveField(() => String, { nullable: true })
+    async kernel(): Promise<string | undefined> {
+        const softwareVersions = await versions();
+        return softwareVersions.kernel;
+    }
+}

--- a/api/src/unraid-api/graph/resolvers/info/versions/get-api-version.ts
+++ b/api/src/unraid-api/graph/resolvers/info/versions/get-api-version.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+let cachedVersion: string | undefined;
+
+export function getApiVersion(): string {
+    if (cachedVersion) {
+        return cachedVersion;
+    }
+
+    try {
+        const packagePath = join(process.cwd(), 'package.json');
+        const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'));
+        cachedVersion = packageJson.version || 'unknown';
+        return cachedVersion;
+    } catch (error) {
+        console.error('Failed to read API version from package.json:', error);
+        return 'unknown';
+    }
+}

--- a/api/src/unraid-api/graph/resolvers/info/versions/versions.model.ts
+++ b/api/src/unraid-api/graph/resolvers/info/versions/versions.model.ts
@@ -2,11 +2,20 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 import { Node } from '@unraid/shared/graphql.model.js';
 
-@ObjectType({ implements: () => Node })
-export class InfoVersions extends Node {
+@ObjectType()
+export class CoreVersions {
+    @Field(() => String, { nullable: true, description: 'Unraid version' })
+    unraid?: string;
+
+    @Field(() => String, { nullable: true, description: 'Unraid API version' })
+    api?: string;
+
     @Field(() => String, { nullable: true, description: 'Kernel version' })
     kernel?: string;
+}
 
+@ObjectType()
+export class PackageVersions {
     @Field(() => String, { nullable: true, description: 'OpenSSL version' })
     openssl?: string;
 
@@ -90,7 +99,13 @@ export class InfoVersions extends Node {
 
     @Field(() => String, { nullable: true, description: 'Docker version' })
     docker?: string;
+}
 
-    @Field(() => String, { nullable: true, description: 'Unraid version' })
-    unraid?: string;
+@ObjectType({ implements: () => Node })
+export class InfoVersions extends Node {
+    @Field(() => CoreVersions, { description: 'Core system versions' })
+    core!: CoreVersions;
+
+    @Field(() => PackageVersions, { description: 'Software package versions' })
+    packages!: PackageVersions;
 }

--- a/api/src/unraid-api/graph/resolvers/info/versions/versions.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/info/versions/versions.resolver.ts
@@ -1,0 +1,63 @@
+import { ConfigService } from '@nestjs/config';
+import { ResolveField, Resolver } from '@nestjs/graphql';
+
+import { versions } from 'systeminformation';
+
+import {
+    CoreVersions,
+    InfoVersions,
+    PackageVersions,
+} from '@app/unraid-api/graph/resolvers/info/versions/versions.model.js';
+
+@Resolver(() => InfoVersions)
+export class VersionsResolver {
+    constructor(private readonly configService: ConfigService) {}
+
+    @ResolveField(() => CoreVersions)
+    core(): CoreVersions {
+        const unraid = this.configService.get<string>('store.emhttp.var.version') || 'unknown';
+        const api = this.configService.get<string>('api.version') || 'unknown';
+
+        return {
+            unraid,
+            api,
+            kernel: undefined, // Will be resolved separately if requested
+        };
+    }
+
+    @ResolveField(() => PackageVersions)
+    async packages(): Promise<PackageVersions> {
+        const softwareVersions = await versions();
+
+        return {
+            openssl: softwareVersions.openssl,
+            systemOpenssl: softwareVersions.systemOpenssl,
+            node: softwareVersions.node,
+            v8: softwareVersions.v8,
+            npm: softwareVersions.npm,
+            yarn: softwareVersions.yarn,
+            pm2: softwareVersions.pm2,
+            gulp: softwareVersions.gulp,
+            grunt: softwareVersions.grunt,
+            git: softwareVersions.git,
+            tsc: softwareVersions.tsc,
+            mysql: softwareVersions.mysql,
+            redis: softwareVersions.redis,
+            mongodb: softwareVersions.mongodb,
+            apache: (softwareVersions as any).apache,
+            nginx: softwareVersions.nginx,
+            php: softwareVersions.php,
+            postfix: softwareVersions.postfix,
+            postgresql: softwareVersions.postgresql,
+            perl: softwareVersions.perl,
+            python: softwareVersions.python,
+            python3: softwareVersions.python3,
+            pip: softwareVersions.pip,
+            pip3: softwareVersions.pip3,
+            java: softwareVersions.java,
+            gcc: softwareVersions.gcc,
+            virtualbox: softwareVersions.virtualbox,
+            docker: softwareVersions.docker,
+        };
+    }
+}

--- a/api/src/unraid-api/graph/resolvers/info/versions/versions.service.ts
+++ b/api/src/unraid-api/graph/resolvers/info/versions/versions.service.ts
@@ -1,22 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-
-import { versions } from 'systeminformation';
 
 import { InfoVersions } from '@app/unraid-api/graph/resolvers/info/versions/versions.model.js';
 
 @Injectable()
 export class VersionsService {
-    constructor(private readonly configService: ConfigService) {}
-
-    async generateVersions(): Promise<InfoVersions> {
-        const unraid = this.configService.get<string>('store.emhttp.var.version') || 'unknown';
-        const softwareVersions = await versions();
-
+    generateVersions(): Partial<InfoVersions> {
         return {
             id: 'info/versions',
-            unraid,
-            ...softwareVersions,
         };
     }
 }

--- a/web/components/ReleaseNotesModal.vue
+++ b/web/components/ReleaseNotesModal.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { ComposerTranslation } from 'vue-i18n';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/solid';
+import { BrandButton, BrandLoading } from '@unraid/ui';
+import Modal from '~/components/Modal.vue';
+import { getReleaseNotesUrl } from '~/helpers/urls';
+
+export interface Props {
+  open: boolean;
+  version: string;
+  t: ComposerTranslation;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+const isLoading = ref(true);
+
+const releaseNotesUrl = computed(() => {
+  return getReleaseNotesUrl(props.version).toString();
+});
+
+const handleIframeLoad = () => {
+  isLoading.value = false;
+};
+
+const handleClose = () => {
+  emit('close');
+};
+
+const openInNewTab = () => {
+  window.open(releaseNotesUrl.value, '_blank');
+};
+</script>
+
+<template>
+  <Modal
+    :center-content="false"
+    max-width="max-w-[800px]"
+    :open="open"
+    :show-close-x="true"
+    :t="t"
+    :tall-content="true"
+    :title="`Unraid OS ${version} Release Notes`"
+    :disable-overlay-close="false"
+    @close="handleClose"
+  >
+    <template #main>
+      <div class="flex flex-col gap-4 min-w-[280px] sm:min-w-[400px]">
+        <!-- Loading state -->
+        <div
+          v-if="isLoading"
+          class="text-center flex flex-col justify-center w-full min-h-[250px] min-w-[280px] sm:min-w-[400px]"
+        >
+          <BrandLoading class="w-[150px] mx-auto mt-6" />
+          <p>Loading release notes…</p>
+        </div>
+        
+        <!-- iframe for release notes -->
+        <div class="w-[calc(100%+3rem)] h-[475px] -mx-6 -my-6">
+          <iframe
+            ref="iframeRef"
+            :src="releaseNotesUrl"
+            class="w-full h-full border-0 rounded-md"
+            sandbox="allow-scripts allow-same-origin"
+            title="Unraid Release Notes"
+            @load="handleIframeLoad"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="flex justify-end">
+        <!-- View on docs button -->
+        <BrandButton
+          variant="underline"
+          :external="true"
+          :href="releaseNotesUrl"
+          :icon="ArrowTopRightOnSquareIcon"
+          aria-label="View on Docs"
+          @click="openInNewTab"
+        >
+          Open in New Tab
+        </BrandButton>
+      </div>
+    </template>
+  </Modal>
+</template>

--- a/web/components/UserProfile/versions.query.ts
+++ b/web/components/UserProfile/versions.query.ts
@@ -1,0 +1,20 @@
+import { graphql } from '~/composables/gql';
+
+export const INFO_VERSIONS_QUERY = graphql(/* GraphQL */ `
+  query InfoVersions {
+    info {
+      id
+      os {
+        id
+        hostname
+      }
+      versions {
+        id
+        core {
+          unraid
+          api
+        }
+      }
+    }
+  }
+`);

--- a/web/composables/api/use-notifications.ts
+++ b/web/composables/api/use-notifications.ts
@@ -39,7 +39,7 @@ export function useHaveSeenNotifications() {
      *
      * Writing this ref will persist to local storage and affect global state.
      */
-    haveSeenNotifications: useStorage<boolean>(HAVE_SEEN_NOTIFICATIONS_KEY, null),
+    haveSeenNotifications: useStorage<boolean>(HAVE_SEEN_NOTIFICATIONS_KEY, false),
   };
 }
 

--- a/web/composables/gql/gql.ts
+++ b/web/composables/gql/gql.ts
@@ -44,6 +44,7 @@ type Documents = {
     "\n  mutation DeleteRCloneRemote($input: DeleteRCloneRemoteInput!) {\n    rclone {\n      deleteRCloneRemote(input: $input)\n    }\n  }\n": typeof types.DeleteRCloneRemoteDocument,
     "\n  query GetRCloneConfigForm($formOptions: RCloneConfigFormInput) {\n    rclone {\n      configForm(formOptions: $formOptions) {\n        id\n        dataSchema\n        uiSchema\n      }\n    }\n  }\n": typeof types.GetRCloneConfigFormDocument,
     "\n  query ListRCloneRemotes {\n    rclone {\n      remotes {\n        name\n        type\n        parameters\n        config\n      }\n    }\n  }\n": typeof types.ListRCloneRemotesDocument,
+    "\n  query InfoVersions {\n    info {\n      id\n      os {\n        id\n        hostname\n      }\n      versions {\n        id\n        core {\n          unraid\n          api\n        }\n      }\n    }\n  }\n": typeof types.InfoVersionsDocument,
     "\n  query OidcProviders {\n    settings {\n      sso {\n        oidcProviders {\n          id\n          name\n          clientId\n          issuer\n          authorizationEndpoint\n          tokenEndpoint\n          jwksUri\n          scopes\n          authorizationRules {\n            claim\n            operator\n            value\n          }\n          authorizationRuleMode\n          buttonText\n          buttonIcon\n        }\n      }\n    }\n  }\n": typeof types.OidcProvidersDocument,
     "\n  query PublicOidcProviders {\n    publicOidcProviders {\n      id\n      name\n      buttonText\n      buttonIcon\n      buttonVariant\n      buttonStyle\n    }\n  }\n": typeof types.PublicOidcProvidersDocument,
     "\n  query serverInfo {\n    info {\n      os {\n        hostname\n      }\n    }\n    vars {\n      comment\n    }\n  }\n": typeof types.ServerInfoDocument,
@@ -86,6 +87,7 @@ const documents: Documents = {
     "\n  mutation DeleteRCloneRemote($input: DeleteRCloneRemoteInput!) {\n    rclone {\n      deleteRCloneRemote(input: $input)\n    }\n  }\n": types.DeleteRCloneRemoteDocument,
     "\n  query GetRCloneConfigForm($formOptions: RCloneConfigFormInput) {\n    rclone {\n      configForm(formOptions: $formOptions) {\n        id\n        dataSchema\n        uiSchema\n      }\n    }\n  }\n": types.GetRCloneConfigFormDocument,
     "\n  query ListRCloneRemotes {\n    rclone {\n      remotes {\n        name\n        type\n        parameters\n        config\n      }\n    }\n  }\n": types.ListRCloneRemotesDocument,
+    "\n  query InfoVersions {\n    info {\n      id\n      os {\n        id\n        hostname\n      }\n      versions {\n        id\n        core {\n          unraid\n          api\n        }\n      }\n    }\n  }\n": types.InfoVersionsDocument,
     "\n  query OidcProviders {\n    settings {\n      sso {\n        oidcProviders {\n          id\n          name\n          clientId\n          issuer\n          authorizationEndpoint\n          tokenEndpoint\n          jwksUri\n          scopes\n          authorizationRules {\n            claim\n            operator\n            value\n          }\n          authorizationRuleMode\n          buttonText\n          buttonIcon\n        }\n      }\n    }\n  }\n": types.OidcProvidersDocument,
     "\n  query PublicOidcProviders {\n    publicOidcProviders {\n      id\n      name\n      buttonText\n      buttonIcon\n      buttonVariant\n      buttonStyle\n    }\n  }\n": types.PublicOidcProvidersDocument,
     "\n  query serverInfo {\n    info {\n      os {\n        hostname\n      }\n    }\n    vars {\n      comment\n    }\n  }\n": types.ServerInfoDocument,
@@ -232,6 +234,10 @@ export function graphql(source: "\n  query GetRCloneConfigForm($formOptions: RCl
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query ListRCloneRemotes {\n    rclone {\n      remotes {\n        name\n        type\n        parameters\n        config\n      }\n    }\n  }\n"): (typeof documents)["\n  query ListRCloneRemotes {\n    rclone {\n      remotes {\n        name\n        type\n        parameters\n        config\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query InfoVersions {\n    info {\n      id\n      os {\n        id\n        hostname\n      }\n      versions {\n        id\n        core {\n          unraid\n          api\n        }\n      }\n    }\n  }\n"): (typeof documents)["\n  query InfoVersions {\n    info {\n      id\n      os {\n        id\n        hostname\n      }\n      versions {\n        id\n        core {\n          unraid\n          api\n        }\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/web/composables/gql/graphql.ts
+++ b/web/composables/gql/graphql.ts
@@ -520,6 +520,16 @@ export enum ContainerState {
   RUNNING = 'RUNNING'
 }
 
+export type CoreVersions = {
+  __typename?: 'CoreVersions';
+  /** Unraid API version */
+  api?: Maybe<Scalars['String']['output']>;
+  /** Kernel version */
+  kernel?: Maybe<Scalars['String']['output']>;
+  /** Unraid version */
+  unraid?: Maybe<Scalars['String']['output']>;
+};
+
 /** CPU load for a single core */
 export type CpuLoad = {
   __typename?: 'CpuLoad';
@@ -1039,67 +1049,11 @@ export type InfoUsb = Node & {
 
 export type InfoVersions = Node & {
   __typename?: 'InfoVersions';
-  /** Apache version */
-  apache?: Maybe<Scalars['String']['output']>;
-  /** Docker version */
-  docker?: Maybe<Scalars['String']['output']>;
-  /** gcc version */
-  gcc?: Maybe<Scalars['String']['output']>;
-  /** Git version */
-  git?: Maybe<Scalars['String']['output']>;
-  /** Grunt version */
-  grunt?: Maybe<Scalars['String']['output']>;
-  /** Gulp version */
-  gulp?: Maybe<Scalars['String']['output']>;
+  /** Core system versions */
+  core: CoreVersions;
   id: Scalars['PrefixedID']['output'];
-  /** Java version */
-  java?: Maybe<Scalars['String']['output']>;
-  /** Kernel version */
-  kernel?: Maybe<Scalars['String']['output']>;
-  /** MongoDB version */
-  mongodb?: Maybe<Scalars['String']['output']>;
-  /** MySQL version */
-  mysql?: Maybe<Scalars['String']['output']>;
-  /** nginx version */
-  nginx?: Maybe<Scalars['String']['output']>;
-  /** Node.js version */
-  node?: Maybe<Scalars['String']['output']>;
-  /** npm version */
-  npm?: Maybe<Scalars['String']['output']>;
-  /** OpenSSL version */
-  openssl?: Maybe<Scalars['String']['output']>;
-  /** Perl version */
-  perl?: Maybe<Scalars['String']['output']>;
-  /** PHP version */
-  php?: Maybe<Scalars['String']['output']>;
-  /** pip version */
-  pip?: Maybe<Scalars['String']['output']>;
-  /** pip3 version */
-  pip3?: Maybe<Scalars['String']['output']>;
-  /** pm2 version */
-  pm2?: Maybe<Scalars['String']['output']>;
-  /** Postfix version */
-  postfix?: Maybe<Scalars['String']['output']>;
-  /** PostgreSQL version */
-  postgresql?: Maybe<Scalars['String']['output']>;
-  /** Python version */
-  python?: Maybe<Scalars['String']['output']>;
-  /** Python3 version */
-  python3?: Maybe<Scalars['String']['output']>;
-  /** Redis version */
-  redis?: Maybe<Scalars['String']['output']>;
-  /** System OpenSSL version */
-  systemOpenssl?: Maybe<Scalars['String']['output']>;
-  /** tsc version */
-  tsc?: Maybe<Scalars['String']['output']>;
-  /** Unraid version */
-  unraid?: Maybe<Scalars['String']['output']>;
-  /** V8 engine version */
-  v8?: Maybe<Scalars['String']['output']>;
-  /** VirtualBox version */
-  virtualbox?: Maybe<Scalars['String']['output']>;
-  /** Yarn version */
-  yarn?: Maybe<Scalars['String']['output']>;
+  /** Software package versions */
+  packages: PackageVersions;
 };
 
 export type InitiateFlashBackupInput = {
@@ -1524,6 +1478,66 @@ export type Owner = {
   avatar: Scalars['String']['output'];
   url: Scalars['String']['output'];
   username: Scalars['String']['output'];
+};
+
+export type PackageVersions = {
+  __typename?: 'PackageVersions';
+  /** Apache version */
+  apache?: Maybe<Scalars['String']['output']>;
+  /** Docker version */
+  docker?: Maybe<Scalars['String']['output']>;
+  /** gcc version */
+  gcc?: Maybe<Scalars['String']['output']>;
+  /** Git version */
+  git?: Maybe<Scalars['String']['output']>;
+  /** Grunt version */
+  grunt?: Maybe<Scalars['String']['output']>;
+  /** Gulp version */
+  gulp?: Maybe<Scalars['String']['output']>;
+  /** Java version */
+  java?: Maybe<Scalars['String']['output']>;
+  /** MongoDB version */
+  mongodb?: Maybe<Scalars['String']['output']>;
+  /** MySQL version */
+  mysql?: Maybe<Scalars['String']['output']>;
+  /** nginx version */
+  nginx?: Maybe<Scalars['String']['output']>;
+  /** Node.js version */
+  node?: Maybe<Scalars['String']['output']>;
+  /** npm version */
+  npm?: Maybe<Scalars['String']['output']>;
+  /** OpenSSL version */
+  openssl?: Maybe<Scalars['String']['output']>;
+  /** Perl version */
+  perl?: Maybe<Scalars['String']['output']>;
+  /** PHP version */
+  php?: Maybe<Scalars['String']['output']>;
+  /** pip version */
+  pip?: Maybe<Scalars['String']['output']>;
+  /** pip3 version */
+  pip3?: Maybe<Scalars['String']['output']>;
+  /** pm2 version */
+  pm2?: Maybe<Scalars['String']['output']>;
+  /** Postfix version */
+  postfix?: Maybe<Scalars['String']['output']>;
+  /** PostgreSQL version */
+  postgresql?: Maybe<Scalars['String']['output']>;
+  /** Python version */
+  python?: Maybe<Scalars['String']['output']>;
+  /** Python3 version */
+  python3?: Maybe<Scalars['String']['output']>;
+  /** Redis version */
+  redis?: Maybe<Scalars['String']['output']>;
+  /** System OpenSSL version */
+  systemOpenssl?: Maybe<Scalars['String']['output']>;
+  /** tsc version */
+  tsc?: Maybe<Scalars['String']['output']>;
+  /** V8 engine version */
+  v8?: Maybe<Scalars['String']['output']>;
+  /** VirtualBox version */
+  virtualbox?: Maybe<Scalars['String']['output']>;
+  /** Yarn version */
+  yarn?: Maybe<Scalars['String']['output']>;
 };
 
 export type ParityCheck = {
@@ -2707,6 +2721,11 @@ export type ListRCloneRemotesQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type ListRCloneRemotesQuery = { __typename?: 'Query', rclone: { __typename?: 'RCloneBackupSettings', remotes: Array<{ __typename?: 'RCloneRemote', name: string, type: string, parameters: any, config: any }> } };
 
+export type InfoVersionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type InfoVersionsQuery = { __typename?: 'Query', info: { __typename?: 'Info', id: string, os: { __typename?: 'InfoOs', id: string, hostname?: string | null }, versions: { __typename?: 'InfoVersions', id: string, core: { __typename?: 'CoreVersions', unraid?: string | null, api?: string | null } } } };
+
 export type OidcProvidersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -2790,6 +2809,7 @@ export const CreateRCloneRemoteDocument = {"kind":"Document","definitions":[{"ki
 export const DeleteRCloneRemoteDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteRCloneRemote"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DeleteRCloneRemoteInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rclone"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteRCloneRemote"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}]}]}}]}}]} as unknown as DocumentNode<DeleteRCloneRemoteMutation, DeleteRCloneRemoteMutationVariables>;
 export const GetRCloneConfigFormDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetRCloneConfigForm"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"formOptions"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"RCloneConfigFormInput"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rclone"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"configForm"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"formOptions"},"value":{"kind":"Variable","name":{"kind":"Name","value":"formOptions"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"dataSchema"}},{"kind":"Field","name":{"kind":"Name","value":"uiSchema"}}]}}]}}]}}]} as unknown as DocumentNode<GetRCloneConfigFormQuery, GetRCloneConfigFormQueryVariables>;
 export const ListRCloneRemotesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListRCloneRemotes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rclone"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"remotes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"parameters"}},{"kind":"Field","name":{"kind":"Name","value":"config"}}]}}]}}]}}]} as unknown as DocumentNode<ListRCloneRemotesQuery, ListRCloneRemotesQueryVariables>;
+export const InfoVersionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"InfoVersions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"info"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"os"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"hostname"}}]}},{"kind":"Field","name":{"kind":"Name","value":"versions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"core"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"unraid"}},{"kind":"Field","name":{"kind":"Name","value":"api"}}]}}]}}]}}]}}]} as unknown as DocumentNode<InfoVersionsQuery, InfoVersionsQueryVariables>;
 export const OidcProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"OidcProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"settings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sso"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oidcProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"clientId"}},{"kind":"Field","name":{"kind":"Name","value":"issuer"}},{"kind":"Field","name":{"kind":"Name","value":"authorizationEndpoint"}},{"kind":"Field","name":{"kind":"Name","value":"tokenEndpoint"}},{"kind":"Field","name":{"kind":"Name","value":"jwksUri"}},{"kind":"Field","name":{"kind":"Name","value":"scopes"}},{"kind":"Field","name":{"kind":"Name","value":"authorizationRules"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"claim"}},{"kind":"Field","name":{"kind":"Name","value":"operator"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}},{"kind":"Field","name":{"kind":"Name","value":"authorizationRuleMode"}},{"kind":"Field","name":{"kind":"Name","value":"buttonText"}},{"kind":"Field","name":{"kind":"Name","value":"buttonIcon"}}]}}]}}]}}]}}]} as unknown as DocumentNode<OidcProvidersQuery, OidcProvidersQueryVariables>;
 export const PublicOidcProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"PublicOidcProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"publicOidcProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"buttonText"}},{"kind":"Field","name":{"kind":"Name","value":"buttonIcon"}},{"kind":"Field","name":{"kind":"Name","value":"buttonVariant"}},{"kind":"Field","name":{"kind":"Name","value":"buttonStyle"}}]}}]}}]} as unknown as DocumentNode<PublicOidcProvidersQuery, PublicOidcProvidersQueryVariables>;
 export const ServerInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"serverInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"info"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"os"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hostname"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"vars"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"comment"}}]}}]}}]} as unknown as DocumentNode<ServerInfoQuery, ServerInfoQueryVariables>;


### PR DESCRIPTION
- Introduced new CoreVersions and PackageVersions types to encapsulate core system and software package version details.
- Updated InfoVersions type to include references to CoreVersions and PackageVersions.
- Modified the versions resolver to return structured version information.
- Added a new query for fetching version information in the frontend.
- Updated the HeaderOsVersion component to display the new version information.
- Created a ReleaseNotesModal component for viewing OS release notes.