### PR TITLE
fix(connect): valid LAN FQDN while remote access is enabled

### DIFF
--- a/packages/unraid-api-plugin-connect/src/network/url-resolver.service.ts
+++ b/packages/unraid-api-plugin-connect/src/network/url-resolver.service.ts
@@ -331,9 +331,10 @@ export class UrlResolverService {
         nginx.fqdnUrls?.forEach((fqdnUrl: FqdnEntry) => {
             doSafely(() => {
                 const urlType = this.getUrlTypeFromFqdn(fqdnUrl.interface);
+                const portToUse = urlType === URL_TYPE.LAN ? nginx.httpsPort : wanport || nginx.httpsPort;
                 const fqdnUrlToUse = this.getUrlForField({
                     url: fqdnUrl.fqdn,
-                    portSsl: Number(wanport || nginx.httpsPort),
+                    portSsl: Number(portToUse),
                 });
 
                 urls.push({


### PR DESCRIPTION
Stop appending `wanport` to LAN FQDN when remote access is enabled.