### PR TITLE
fix: rm redundant emission to `$HOME/.pm2/logs`

### DIFF
--- a/api/ecosystem.config.json
+++ b/api/ecosystem.config.json
@@ -13,7 +13,9 @@
             "watch": false,
             "interpreter": "/usr/local/bin/node",
             "ignore_watch": ["node_modules", "src", ".env.*", "myservers.cfg"],
-            "log_file": "/var/log/graphql-api.log",
+            "out_file": "/var/log/graphql-api.log",
+            "error_file": "/var/log/graphql-api.log",
+            "merge_logs": true,
             "kill_timeout": 10000
         }
     ]


### PR DESCRIPTION
Override the pm2 daemon's emission of `logs/unraid-api-{out,error}.log`, which is a duplicate of the stdout appended to `/var/log/graphql-api.log`. 

Correctly implements the sane interpretation of what the `log_file` configuration does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved process logging by separating standard output and error streams while supporting merged logs when multiple sources are present.
  * Enhances log clarity and troubleshooting without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->