### PR TITLE
fix: use shared bg & border color for styled toasts

### DIFF
--- a/@tailwind-shared/sonner.css
+++ b/@tailwind-shared/sonner.css
@@ -433,6 +433,23 @@
   --error-bg: hsl(var(--background));
   --error-border: hsl(var(--border));
   --error-text: hsl(360, 100%, 45%);
+
+  /* Old colors, preserved for reference
+  --success-bg: hsl(143, 85%, 96%);
+  --success-border: hsl(145, 92%, 91%);
+  --success-text: hsl(140, 100%, 27%);
+
+  --info-bg: hsl(208, 100%, 97%);
+  --info-border: hsl(221, 91%, 91%);
+  --info-text: hsl(210, 92%, 45%);
+
+  --warning-bg: hsl(49, 100%, 97%);
+  --warning-border: hsl(49, 91%, 91%);
+  --warning-text: hsl(31, 92%, 45%);
+
+  --error-bg: hsl(359, 100%, 97%);
+  --error-border: hsl(359, 100%, 94%);
+  --error-text: hsl(360, 100%, 45%); */
 }
 
 [data-sonner-toaster][data-theme='light'] [data-sonner-toast][data-invert='true'] {
@@ -467,6 +484,23 @@
   --error-bg: hsl(var(--background));
   --error-border: hsl(var(--border));
   --error-text: hsl(358, 100%, 81%);
+
+  /* Old colors, preserved for reference
+  --success-bg: hsl(150, 100%, 6%);
+  --success-border: hsl(147, 100%, 12%);
+  --success-text: hsl(150, 86%, 65%);
+
+  --info-bg: hsl(215, 100%, 6%);
+  --info-border: hsl(223, 100%, 12%);
+  --info-text: hsl(216, 87%, 65%);
+
+  --warning-bg: hsl(64, 100%, 6%);
+  --warning-border: hsl(60, 100%, 12%);
+  --warning-text: hsl(46, 87%, 65%);
+
+  --error-bg: hsl(358, 76%, 10%);
+  --error-border: hsl(357, 89%, 16%);
+  --error-text: hsl(358, 100%, 81%); */
 }
 
 [data-rich-colors='true'][data-sonner-toast][data-type='success'] {


### PR DESCRIPTION
Addresses user complaints about light colored notifications in dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced type-specific toast color tokens (success, info, warning, error) for richer, clearer toast styling.
  - Applied consistent theming across light, inverted, and dark modes to improve readability and contrast.
  - Enabled compatibility with rich color settings for toasts.
- Bug Fixes
  - Corrected a CSS comment block to ensure styles compile and apply reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->