### PR TITLE
fix(plugin): restore cleanup behavior for unsupported unraid versions

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -85,7 +85,7 @@ exit(0);
   <FILE Name="/tmp/unraid_connect_cleanup_for_unsupported_os_versions.sh" Run="/bin/bash" Method="install" Max="6.12.0">
     <INLINE>
       <![CDATA[
-# Inlined copy of perform_connect_cleanup and perform_full_cleanup from
+# Inlined copy of perform_connect_cleanup from
 # /usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
 # to avoid the need to decompress the plugin tarball just to run the cleanup script
 
@@ -164,68 +164,8 @@ perform_connect_cleanup() {
   fi
 }
 
-# Full cleanup function - runs only during removal
-perform_full_cleanup() {
-  # Clean up Connect and Flash Backup services
-  perform_connect_cleanup
-  
-  # Stop and remove the API
-  if [ -e /etc/rc.d/rc.unraid-api ]; then
-    # Stop flash backup
-    /etc/rc.d/rc.flash_backup stop >/dev/null 2>&1
-    # Stop the api gracefully
-    /etc/rc.d/rc.unraid-api stop >/dev/null 2>&1
-    # Stop newer clients
-    unraid-api stop
-    # Kill any processes
-    pid_list=$(pidof unraid-api 2>/dev/null) || true
-    [ -n "$pid_list" ] && kill -9 $pid_list
-    # Find all PIDs referencing main.js and kill them
-    node_pids=$(pgrep -f "node /usr/local/unraid-api/dist/main.js" 2>/dev/null) || true
-    [ -n "$node_pids" ] && echo "$node_pids" | xargs kill -9
-    # Clean up files
-    rm -rf /usr/local/unraid-api
-    rm -rf /var/run/unraid-api.sock
-    rm -rf /usr/.pnpm-store
-  fi
-
-  # Delete plugin files and cleanup
-  rm -f /boot/config/plugins/dynamix.my.servers/.gitignore
-  rm -f /etc/rc.d/rc.unraid-api
-  rm -f /etc/rc.d/rc.flash_backup
-  rm -rf /usr/local/sbin/unraid-api
-  rm -rf /usr/local/bin/unraid-api
-  rm -rf /usr/local/emhttp/plugins/dynamix.unraid.net
-  rm -rf /usr/local/emhttp/plugins/dynamix.unraid.net.staging
-  rm -f /etc/rc.d/rc6.d/K10_flash_backup
-  rm -f /var/log/gitcount
-  rm -f /var/log/gitflash
-  rm -f /var/log/gitratelimit
-  rm -f /usr/local/emhttp/state/flashbackup.ini
-  rm -f /usr/local/emhttp/state/myservers.cfg
-  
-  # Delete any legacy files that may exist
-  rm -rf /boot/config/plugins/dynamix.my.servers/libvirt.node
-  rm -rf /boot/config/plugins/dynamix.my.servers/segfault-handler.node
-  rm -rf /boot/config/plugins/dynamix.my.servers/wc
-  rm -f /boot/config/plugins/Unraid.net/unraid-api.tgz
-  rm -f /boot/config/plugins/Unraid.net/.gitignore
-  rm -f /boot/config/plugins/dynamix.my.servers/unraid-api.tgz
-  rm -rf /boot/config/plugins/Unraid.net/webComps
-  rm -rf /boot/config/plugins/Unraid.net/wc
-  rm -f /usr/local/emhttp/webGui/javascript/vue.js
-  rm -f /usr/local/emhttp/webGui/javascript/vue.min.js
-  rm -rf /usr/local/emhttp/webGui/webComps
-  rm -rf /usr/local/emhttp/webGui/wc
-  
-  # Clean up our optional makestate modifications in rc.nginx (on 6.9 and 6.10.0-rc[12])
-  sed -i '/scripts\/makestate/d' /etc/rc.d/rc.nginx
-  # Clean up extra origin for robots.txt
-  sed -i '/#robots.txt any origin/d' /etc/rc.d/rc.nginx
-}
-
-perform_full_cleanup
-echo "Done."
+perform_connect_cleanup
+echo "Done. Please uninstall the Connect plugin to complete the cleanup."
 # Exit with error to clarify that further user action--either uninstalling the plugin or upgrading to a newer version of Unraid--is required.
 exit 1;
 ]]>

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -14,7 +14,7 @@
   <!ENTITY tag "">
   <!ENTITY api_version "">
 ]>
-<!-- Plugin min version is lower than the actual min version of Connect (6.12.15) to facilitate cleanup on newly unsupported versions. -->
+<!-- Plugin min version is lower than the actual min version of Connect (6.12.0) to facilitate cleanup on newly unsupported versions. -->
 <PLUGIN name="&name;" author="&author;" version="&version;" pluginURL="&plugin_url;"
   launch="&launch;" min="6.9.0-rc1" icon="globe">
 
@@ -60,9 +60,9 @@ exit 0
 // Check Unraid version
 $version = @parse_ini_file('/etc/unraid-version', true)['version'];
 
-// Check if this is a supported version
-// - Must be 6.12.15 or higher
-// - Must not be a 6.12.15 beta/rc version
+// Check if this is a recommended version
+// - Should be 6.12.15 or higher
+// - Should not be a 6.12.15 beta/rc version
 $is_stable_6_12_or_higher = version_compare($version, '6.12.15', '>=') && !preg_match('/^6\\.12\\.15-/', $version);
 
 if ($is_stable_6_12_or_higher) {
@@ -71,17 +71,17 @@ if ($is_stable_6_12_or_higher) {
 }
 
 echo "Warning: Unsupported Unraid version {$version}. This plugin requires Unraid 6.12.15 or higher.\n";
-echo "The plugin will not function correctly on this system.\n";
-echo "Will cleanup automatically.\n";
+echo "The plugin may not function correctly on this system.\n";
 echo "⚠️ Please uninstall this plugin or upgrade to a newer version of Unraid to enjoy Unraid Connect\n";
 
+// early escape handled via unraid_connect_cleanup_for_unsupported_os_versions step
 exit(0);
 ]]>
     </INLINE>
   </FILE>
 
-<!-- cleanup script for Unraid 6.12.14 and earlier. when run, it will exit the plugin install with an error status. -->
-  <File Name="unraid_connect_deprecation_cleanup" Run="/bin/bash" Method="install" Max="6.12.14">
+<!-- cleanup script for Unraid 6.12.0 and earlier. when run, it will exit the plugin install with an error status. -->
+  <File Name="/tmp/unraid_connect_cleanup_for_unsupported_os_versions.sh" Run="/bin/bash" Method="install" Max="6.12.0">
     <INLINE>
       <![CDATA[
 # Inlined copy of /usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -14,9 +14,9 @@
   <!ENTITY tag "">
   <!ENTITY api_version "">
 ]>
-
+<!-- Plugin min version is lower than the actual min version of Connect (6.12.15) to facilitate cleanup on newly unsupported versions. -->
 <PLUGIN name="&name;" author="&author;" version="&version;" pluginURL="&plugin_url;"
-  launch="&launch;" min="6.12.15" icon="globe">
+  launch="&launch;" min="6.9.0-rc1" icon="globe">
 
   <CHANGES>
     ##a long time ago in a galaxy far far away
@@ -63,7 +63,7 @@ $version = @parse_ini_file('/etc/unraid-version', true)['version'];
 // Check if this is a supported version
 // - Must be 6.12.15 or higher
 // - Must not be a 6.12.15 beta/rc version
-$is_stable_6_12_or_higher = version_compare($version, '6.12.15', '>=') && !preg_match('/^6\\.12\\.0-/', $version);
+$is_stable_6_12_or_higher = version_compare($version, '6.12.15', '>=') && !preg_match('/^6\\.12\\.15-/', $version);
 
 if ($is_stable_6_12_or_higher) {
   echo "Running on supported version {$version}\n";
@@ -72,8 +72,160 @@ if ($is_stable_6_12_or_higher) {
 
 echo "Warning: Unsupported Unraid version {$version}. This plugin requires Unraid 6.12.15 or higher.\n";
 echo "The plugin will not function correctly on this system.\n";
+echo "Will cleanup automatically.\n";
+echo "⚠️ Please uninstall this plugin or upgrade to a newer version of Unraid to enjoy Unraid Connect\n";
 
-exit(1);
+exit(0);
+]]>
+    </INLINE>
+  </FILE>
+
+<!-- cleanup script for Unraid 6.12.14 and earlier. when run, it will exit the plugin install with an error status. -->
+  <File Name="unraid_connect_deprecation_cleanup" Run="/bin/bash" Method="install" Max="6.12.14">
+    <INLINE>
+      <![CDATA[
+# Inlined copy of /usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
+# to avoid the need to decompress the plugin tarball just to run the cleanup script
+
+# Handle flash backup deactivation and Connect signout
+perform_connect_cleanup() {
+  printf "\n**********************************\n"
+  printf "🧹 CLEANING UP - may take a minute\n"
+  printf "**********************************\n"
+  
+  # Handle git-based flash backups
+  if [ -f "/boot/.git" ]; then
+    if [ -f "/etc/rc.d/rc.flash_backup" ]; then
+      printf "\nStopping flash backup service. Please wait...\n"
+      /etc/rc.d/rc.flash_backup stop >/dev/null 2>&1
+    fi
+    
+    if [ -f "/usr/local/emhttp/plugins/dynamix.my.servers/include/UpdateFlashBackup.php" ]; then
+      printf "\nDeactivating flash backup. Please wait...\n"
+      /usr/bin/php /usr/local/emhttp/plugins/dynamix.my.servers/include/UpdateFlashBackup.php deactivate
+    fi
+  fi
+  
+  # Check if connect.json or myservers.cfg exists
+  if [ -f "/boot/config/plugins/dynamix.my.servers/configs/connect.json" ] || [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
+    # Stop unraid-api
+    printf "\nStopping unraid-api. Please wait...\n"
+    output=$(/etc/rc.d/rc.unraid-api stop --delete 2>&1)
+    if [ -z "$output" ]; then
+      echo "Waiting for unraid-api to stop..."
+      sleep 5  # Give it time to stop
+    fi
+    echo "Stopped unraid-api: $output"
+    
+    # Sign out of Unraid Connect (we'll use curl directly from shell)
+    # We need to extract the username from connect.json or myservers.cfg and the registration key
+    has_username=false
+    
+    # Check connect.json first (newer format)
+    if [ -f "/boot/config/plugins/dynamix.my.servers/configs/connect.json" ] && command -v jq >/dev/null 2>&1; then
+      username=$(jq -r '.username' "/boot/config/plugins/dynamix.my.servers/configs/connect.json" 2>/dev/null)
+      if [ -n "$username" ] && [ "$username" != "null" ]; then
+        has_username=true
+      fi
+    fi
+    
+    # Fallback to myservers.cfg (legacy format)
+    if [ "$has_username" = false ] && [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
+      if grep -q 'username' "/boot/config/plugins/dynamix.my.servers/myservers.cfg"; then
+        has_username=true
+      fi
+    fi
+    
+    if [ "$has_username" = true ]; then
+      printf "\nSigning out of Unraid Connect\n"
+      # Check if regFILE exists in var.ini
+      if [ -f "/var/local/emhttp/var.ini" ]; then
+        regfile=$(grep "regFILE" "/var/local/emhttp/var.ini" | cut -d= -f2)
+        if [ -n "$regfile" ] && [ -f "$regfile" ]; then
+          # Base64 encode the key file and send to server
+          encoded_key=$(base64 "$regfile" | tr -d '\n')
+          if [ -n "$encoded_key" ]; then
+            curl -s -X POST "https://keys.lime-technology.com/account/server/unregister" \
+              -d "keyfile=$encoded_key" >/dev/null 2>&1
+          fi
+        fi
+      fi
+    fi
+    
+    # Remove config files
+    rm -f /boot/config/plugins/dynamix.my.servers/myservers.cfg
+    rm -f /boot/config/plugins/dynamix.my.servers/configs/connect.json
+    
+    # Reload nginx to disable Remote Access
+    printf "\n⚠️ Reloading Web Server. If this window stops updating for two minutes please close it.\n"
+    /etc/rc.d/rc.nginx reload >/dev/null 2>&1
+  fi
+}
+
+# Full cleanup function - runs only during removal
+perform_full_cleanup() {
+  # Clean up Connect and Flash Backup services
+  perform_connect_cleanup
+  
+  # Stop and remove the API
+  if [ -e /etc/rc.d/rc.unraid-api ]; then
+    # Stop flash backup
+    /etc/rc.d/rc.flash_backup stop >/dev/null 2>&1
+    # Stop the api gracefully
+    /etc/rc.d/rc.unraid-api stop >/dev/null 2>&1
+    # Stop newer clients
+    unraid-api stop
+    # Kill any processes
+    pid_list=$(pidof unraid-api 2>/dev/null) || true
+    [ -n "$pid_list" ] && kill -9 $pid_list
+    # Find all PIDs referencing main.js and kill them
+    node_pids=$(pgrep -f "node /usr/local/unraid-api/dist/main.js" 2>/dev/null) || true
+    [ -n "$node_pids" ] && echo "$node_pids" | xargs kill -9
+    # Clean up files
+    rm -rf /usr/local/unraid-api
+    rm -rf /var/run/unraid-api.sock
+    rm -rf /usr/.pnpm-store
+  fi
+
+  # Delete plugin files and cleanup
+  rm -f /boot/config/plugins/dynamix.my.servers/.gitignore
+  rm -f /etc/rc.d/rc.unraid-api
+  rm -f /etc/rc.d/rc.flash_backup
+  rm -rf /usr/local/sbin/unraid-api
+  rm -rf /usr/local/bin/unraid-api
+  rm -rf /usr/local/emhttp/plugins/dynamix.unraid.net
+  rm -rf /usr/local/emhttp/plugins/dynamix.unraid.net.staging
+  rm -f /etc/rc.d/rc6.d/K10_flash_backup
+  rm -f /var/log/gitcount
+  rm -f /var/log/gitflash
+  rm -f /var/log/gitratelimit
+  rm -f /usr/local/emhttp/state/flashbackup.ini
+  rm -f /usr/local/emhttp/state/myservers.cfg
+  
+  # Delete any legacy files that may exist
+  rm -rf /boot/config/plugins/dynamix.my.servers/libvirt.node
+  rm -rf /boot/config/plugins/dynamix.my.servers/segfault-handler.node
+  rm -rf /boot/config/plugins/dynamix.my.servers/wc
+  rm -f /boot/config/plugins/Unraid.net/unraid-api.tgz
+  rm -f /boot/config/plugins/Unraid.net/.gitignore
+  rm -f /boot/config/plugins/dynamix.my.servers/unraid-api.tgz
+  rm -rf /boot/config/plugins/Unraid.net/webComps
+  rm -rf /boot/config/plugins/Unraid.net/wc
+  rm -f /usr/local/emhttp/webGui/javascript/vue.js
+  rm -f /usr/local/emhttp/webGui/javascript/vue.min.js
+  rm -rf /usr/local/emhttp/webGui/webComps
+  rm -rf /usr/local/emhttp/webGui/wc
+  
+  # Clean up our optional makestate modifications in rc.nginx (on 6.9 and 6.10.0-rc[12])
+  sed -i '/scripts\/makestate/d' /etc/rc.d/rc.nginx
+  # Clean up extra origin for robots.txt
+  sed -i '/#robots.txt any origin/d' /etc/rc.d/rc.nginx
+}
+
+perform_full_cleanup
+echo "Done."
+# Exit with error to clarify that further user action--either uninstalling the plugin or upgrading to a newer version of Unraid--is required.
+exit 1;
 ]]>
     </INLINE>
   </FILE>

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -71,7 +71,7 @@ if ($is_stable_6_12_or_higher) {
 }
 
 echo "Warning: Unsupported Unraid version {$version}. This plugin requires Unraid 6.12.15 or higher.\n";
-echo "The plugin may not function correctly on this system.\n";
+echo "The plugin may not function correctly on this system. It may stop working entirely in the future.\n";
 echo "⚠️ Please uninstall this plugin or upgrade to a newer version of Unraid to enjoy Unraid Connect\n";
 
 // early escape handled via unraid_connect_cleanup_for_unsupported_os_versions step

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -81,6 +81,7 @@ exit(0);
   </FILE>
 
 <!-- cleanup script for Unraid 6.12.0 and earlier. when run, it will exit the plugin install with an error status. -->
+<!-- See the version of dynamix.unraid.net.plg in commit a240a031a for the original implementation of this code. -->
   <File Name="/tmp/unraid_connect_cleanup_for_unsupported_os_versions.sh" Run="/bin/bash" Method="install" Max="6.12.0">
     <INLINE>
       <![CDATA[

--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -82,10 +82,11 @@ exit(0);
 
 <!-- cleanup script for Unraid 6.12.0 and earlier. when run, it will exit the plugin install with an error status. -->
 <!-- See the version of dynamix.unraid.net.plg in commit a240a031a for the original implementation of this code. -->
-  <File Name="/tmp/unraid_connect_cleanup_for_unsupported_os_versions.sh" Run="/bin/bash" Method="install" Max="6.12.0">
+  <FILE Name="/tmp/unraid_connect_cleanup_for_unsupported_os_versions.sh" Run="/bin/bash" Method="install" Max="6.12.0">
     <INLINE>
       <![CDATA[
-# Inlined copy of /usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
+# Inlined copy of perform_connect_cleanup and perform_full_cleanup from
+# /usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
 # to avoid the need to decompress the plugin tarball just to run the cleanup script
 
 # Handle flash backup deactivation and Connect signout
@@ -129,7 +130,7 @@ perform_connect_cleanup() {
         has_username=true
       fi
     fi
-    
+
     # Fallback to myservers.cfg (legacy format)
     if [ "$has_username" = false ] && [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
       if grep -q 'username' "/boot/config/plugins/dynamix.my.servers/myservers.cfg"; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds guided warnings and an explicit cleanup/uninstall workflow for unsupported Unraid versions, with safer removal paths by OS release.

* **Bug Fixes**
  * Detects and removes both new and legacy Connect configurations, ensuring proper sign-out and web-server reload.
  * Strengthens version gating to avoid problematic pre-release builds and advises uninstall/upgrade when needed.

* **Chores**
  * Lowers declared minimum Unraid version to broaden compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->