### PR TITLE
fix: Revert "fix(cli): support `--log-level` for `start` and `restart` cmds"

### DIFF
--- a/api/docs/public/cli.md
+++ b/api/docs/public/cli.md
@@ -21,14 +21,7 @@ unraid-api start [--log-level <level>]
 Starts the Unraid API service.
 
 Options:
-
-- `--log-level`: Set logging level (trace|debug|info|warn|error|fatal)
-
-Alternative: You can also set the log level using the `LOG_LEVEL` environment variable:
-
-```bash
-LOG_LEVEL=trace unraid-api start
-```
+- `--log-level`: Set logging level (trace|debug|info|warn|error)
 
 ### Stop
 
@@ -43,20 +36,10 @@ Stops the Unraid API service.
 ### Restart
 
 ```bash
-unraid-api restart [--log-level <level>]
+unraid-api restart
 ```
 
 Restarts the Unraid API service.
-
-Options:
-
-- `--log-level`: Set logging level (trace|debug|info|warn|error|fatal)
-
-Alternative: You can also set the log level using the `LOG_LEVEL` environment variable:
-
-```bash
-LOG_LEVEL=trace unraid-api restart
-```
 
 ### Logs
 

--- a/api/src/unraid-api/cli/restart.command.ts
+++ b/api/src/unraid-api/cli/restart.command.ts
@@ -1,22 +1,8 @@
-import { Command, CommandRunner, Option } from 'nest-commander';
+import { Command, CommandRunner } from 'nest-commander';
 
-import type { LogLevel } from '@app/core/log.js';
-import { levels } from '@app/core/log.js';
-import { ECOSYSTEM_PATH, LOG_LEVEL } from '@app/environment.js';
+import { ECOSYSTEM_PATH } from '@app/environment.js';
 import { LogService } from '@app/unraid-api/cli/log.service.js';
 import { PM2Service } from '@app/unraid-api/cli/pm2.service.js';
-
-export interface LogLevelOptions {
-    logLevel?: LogLevel;
-}
-
-export function parseLogLevelOption(val: string, allowedLevels: string[] = [...levels]): LogLevel {
-    const normalized = val.toLowerCase() as LogLevel;
-    if (allowedLevels.includes(normalized)) {
-        return normalized;
-    }
-    throw new Error(`Invalid --log-level "${val}". Allowed: ${allowedLevels.join(', ')}`);
-}
 
 @Command({ name: 'restart', description: 'Restart the Unraid API' })
 export class RestartCommand extends CommandRunner {
@@ -27,12 +13,11 @@ export class RestartCommand extends CommandRunner {
         super();
     }
 
-    async run(_?: string[], options: LogLevelOptions = {}): Promise<void> {
+    async run(): Promise<void> {
         try {
             this.logger.info('Restarting the Unraid API...');
-            const env = { LOG_LEVEL: options.logLevel };
             const { stderr, stdout } = await this.pm2.run(
-                { tag: 'PM2 Restart', raw: true, extendEnv: true, env },
+                { tag: 'PM2 Restart', raw: true },
                 'restart',
                 ECOSYSTEM_PATH,
                 '--update-env'
@@ -54,14 +39,5 @@ export class RestartCommand extends CommandRunner {
             }
             process.exit(1);
         }
-    }
-
-    @Option({
-        flags: `--log-level <${levels.join('|')}>`,
-        description: 'log level to use',
-        defaultValue: LOG_LEVEL.toLowerCase(),
-    })
-    parseLogLevel(val: string): LogLevel {
-        return parseLogLevelOption(val);
     }
 }

--- a/api/src/unraid-api/cli/start.command.ts
+++ b/api/src/unraid-api/cli/start.command.ts
@@ -1,12 +1,14 @@
 import { Command, CommandRunner, Option } from 'nest-commander';
 
 import type { LogLevel } from '@app/core/log.js';
-import type { LogLevelOptions } from '@app/unraid-api/cli/restart.command.js';
 import { levels } from '@app/core/log.js';
-import { ECOSYSTEM_PATH, LOG_LEVEL } from '@app/environment.js';
+import { ECOSYSTEM_PATH } from '@app/environment.js';
 import { LogService } from '@app/unraid-api/cli/log.service.js';
 import { PM2Service } from '@app/unraid-api/cli/pm2.service.js';
-import { parseLogLevelOption } from '@app/unraid-api/cli/restart.command.js';
+
+interface StartCommandOptions {
+    'log-level'?: string;
+}
 
 @Command({ name: 'start', description: 'Start the Unraid API' })
 export class StartCommand extends CommandRunner {
@@ -25,12 +27,17 @@ export class StartCommand extends CommandRunner {
         await this.pm2.run({ tag: 'PM2 Delete' }, 'delete', ECOSYSTEM_PATH);
     }
 
-    async run(_: string[], options: LogLevelOptions): Promise<void> {
+    async run(_: string[], options: StartCommandOptions): Promise<void> {
         this.logger.info('Starting the Unraid API');
         await this.cleanupPM2State();
-        const env = { LOG_LEVEL: options.logLevel };
+
+        const env: Record<string, string> = {};
+        if (options['log-level']) {
+            env.LOG_LEVEL = options['log-level'];
+        }
+
         const { stderr, stdout } = await this.pm2.run(
-            { tag: 'PM2 Start', raw: true, extendEnv: true, env },
+            { tag: 'PM2 Start', env, raw: true },
             'start',
             ECOSYSTEM_PATH,
             '--update-env'
@@ -47,9 +54,9 @@ export class StartCommand extends CommandRunner {
     @Option({
         flags: `--log-level <${levels.join('|')}>`,
         description: 'log level to use',
-        defaultValue: LOG_LEVEL.toLowerCase(),
+        defaultValue: 'info',
     })
     parseLogLevel(val: string): LogLevel {
-        return parseLogLevelOption(val);
+        return levels.includes(val as LogLevel) ? (val as LogLevel) : 'info';
     }
 }


### PR DESCRIPTION
Reverts unraid/api#1623

This broke environment on startup on Unraid 7.2 beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Breaking Changes
  * Restart: Removed support for --log-level and LOG_LEVEL; use simply "unraid-api restart".
  * Start: LOG_LEVEL env no longer supported; use --log-level to set verbosity. Invalid values now fall back to "info" by default.

* Documentation
  * Updated CLI docs to remove environment-variable guidance for Start and Restart and reflect the streamlined options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->