### PR TITLE
fix(plugin): add fallback for unraid-api stop in deprecation cleanup

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -112,12 +112,13 @@ perform_connect_cleanup() {
   if [ -f "/boot/config/plugins/dynamix.my.servers/configs/connect.json" ] || [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
     # Stop unraid-api
     printf "\nStopping unraid-api. Please wait...\n"
-    output=$(/etc/rc.d/rc.unraid-api stop --delete 2>&1)
-    if [ -z "$output" ]; then
-      echo "Waiting for unraid-api to stop..."
-      sleep 5  # Give it time to stop
+    if [ -f "/etc/rc.d/rc.unraid-api" ]; then
+      /etc/rc.d/rc.unraid-api stop 2>&1
+    elif command -v unraid-api >/dev/null 2>&1; then
+      unraid-api stop 2>&1
+    else
+      echo "⚠️ Warning: Neither /etc/rc.d/rc.unraid-api nor unraid-api command found"
     fi
-    echo "Stopped unraid-api: $output"
     
     # Sign out of Unraid Connect (we'll use curl directly from shell)
     # We need to extract the username from connect.json or myservers.cfg and the registration key
@@ -130,7 +131,7 @@ perform_connect_cleanup() {
         has_username=true
       fi
     fi
-
+    
     # Fallback to myservers.cfg (legacy format)
     if [ "$has_username" = false ] && [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
       if grep -q 'username' "/boot/config/plugins/dynamix.my.servers/myservers.cfg"; then

--- a/plugin/source/dynamix.unraid.net/usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
+++ b/plugin/source/dynamix.unraid.net/usr/local/share/dynamix.unraid.net/install/scripts/cleanup.sh
@@ -29,12 +29,13 @@ perform_connect_cleanup() {
   if [ -f "/boot/config/plugins/dynamix.my.servers/configs/connect.json" ] || [ -f "/boot/config/plugins/dynamix.my.servers/myservers.cfg" ]; then
     # Stop unraid-api
     printf "\nStopping unraid-api. Please wait...\n"
-    output=$(/etc/rc.d/rc.unraid-api stop --delete 2>&1)
-    if [ -z "$output" ]; then
-      echo "Waiting for unraid-api to stop..."
-      sleep 5  # Give it time to stop
+    if [ -f "/etc/rc.d/rc.unraid-api" ]; then
+      /etc/rc.d/rc.unraid-api stop 2>&1
+    elif command -v unraid-api >/dev/null 2>&1; then
+      unraid-api stop 2>&1
+    else
+      echo "⚠️ Warning: Neither /etc/rc.d/rc.unraid-api nor unraid-api command found"
     fi
-    echo "Stopped unraid-api: $output"
     
     # Sign out of Unraid Connect (we'll use curl directly from shell)
     # We need to extract the username from connect.json or myservers.cfg and the registration key


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of service shutdown during account disconnect/cleanup, handling environments where the service script or CLI may be missing.
  * Removed unnecessary delays during shutdown, resulting in a faster and smoother disconnect process.
  * Added clearer warning messaging when the service cannot be found.

* **Chores**
  * Minor whitespace cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->