### PR TITLE
fix: hide reset help option when sso is being checked

### DIFF
--- a/web/src/components/SsoButton.standalone.vue
+++ b/web/src/components/SsoButton.standalone.vue
@@ -1,9 +1,50 @@
 <script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue';
+
 import SsoButtons from '~/components/sso/SsoButtons.vue';
+
+const handleSsoStatus = (status: { checking: boolean; loading: boolean }) => {
+  // Find the password recovery link on the page
+  const passwordRecoveryLink = document.querySelector(
+    'a[href*="lost-root-password"]'
+  ) as HTMLAnchorElement;
+
+  if (passwordRecoveryLink) {
+    // Hide the link when checking API or loading
+    if (status.checking || status.loading) {
+      passwordRecoveryLink.style.display = 'none';
+    } else {
+      // Show it again when not checking/loading
+      passwordRecoveryLink.style.display = '';
+    }
+  }
+};
+
+// Also hide password recovery initially while checking
+onMounted(() => {
+  const passwordRecoveryLink = document.querySelector(
+    'a[href*="lost-root-password"]'
+  ) as HTMLAnchorElement;
+  if (passwordRecoveryLink) {
+    // Store original display value
+    const originalDisplay = passwordRecoveryLink.style.display || '';
+    passwordRecoveryLink.dataset.originalDisplay = originalDisplay;
+  }
+});
+
+// Restore on unmount
+onUnmounted(() => {
+  const passwordRecoveryLink = document.querySelector(
+    'a[href*="lost-root-password"]'
+  ) as HTMLAnchorElement;
+  if (passwordRecoveryLink && passwordRecoveryLink.dataset.originalDisplay !== undefined) {
+    passwordRecoveryLink.style.display = passwordRecoveryLink.dataset.originalDisplay;
+  }
+});
 </script>
 
 <template>
-  <SsoButtons />
+  <SsoButtons @sso-status="handleSsoStatus" />
 </template>
 
 <!-- Font size overrides are handled in component-registry.ts for custom elements -->

--- a/web/src/components/sso/SsoButtons.vue
+++ b/web/src/components/sso/SsoButtons.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import SsoProviderButton from '~/components/sso/SsoProviderButton.vue';
 import { useSsoAuth } from '~/components/sso/useSsoAuth';
 import { useSsoProviders } from '~/components/sso/useSsoProviders';
+
+const emit = defineEmits<{
+  'sso-status': [status: { checking: boolean; loading: boolean }];
+}>();
 
 const { t } = useI18n();
 const { oidcProviders, hasProviders, checkingApi } = useSsoProviders();
@@ -13,6 +17,15 @@ const { currentState, error, navigateToProvider } = useSsoAuth();
 const showError = computed(() => currentState.value === 'error');
 const showOr = computed(() => (currentState.value === 'idle' || showError.value) && hasProviders.value);
 const isLoading = computed(() => currentState.value === 'loading');
+
+// Emit status changes
+watch(
+  [checkingApi, isLoading],
+  ([checking, loading]) => {
+    emit('sso-status', { checking, loading });
+  },
+  { immediate: true }
+);
 </script>
 
 <template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Enhancements
  - Improved SSO sign-in experience on the login screen. The “Forgot your password?” link is now automatically hidden while SSO status is being checked or a provider is loading, and restored once ready. This reduces confusion and visual flicker during authentication, ensuring a cleaner, more stable layout throughout the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->