### PR TITLE
fix: display settings fix for languages on less than 7.2-beta.2.3

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/modifications/display-settings.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/display-settings.modification.ts
@@ -1,6 +1,9 @@
 import { readFile } from 'node:fs/promises';
 
-import { FileModification } from '@app/unraid-api/unraid-file-modifier/file-modification.js';
+import {
+    FileModification,
+    ShouldApplyWithReason,
+} from '@app/unraid-api/unraid-file-modifier/file-modification.js';
 
 export default class DisplaySettingsModification extends FileModification {
     id: string = 'display-settings';
@@ -33,5 +36,16 @@ export default class DisplaySettingsModification extends FileModification {
         const newContent = await this.applyToSource(fileContent);
 
         return this.createPatchWithDiff(overridePath ?? this.filePath, fileContent, newContent);
+    }
+
+    async shouldApply(): Promise<ShouldApplyWithReason> {
+        const superShouldApply = await super.shouldApply();
+        if (!superShouldApply.shouldApply) {
+            return superShouldApply;
+        }
+        return {
+            shouldApply: true,
+            reason: 'Display settings modification needed for Unraid version <= 7.2.0-beta.2.3',
+        };
     }
 }


### PR DESCRIPTION
…less

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Display settings modification now applies conditionally for specific Unraid versions (<= 7.2.0-beta.2.3), providing a clear reason when it’s applicable.
  - Improves transparency and control over when the modification is executed without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->