### PR TITLE
Fix: Connect won't appear within Apps - Previous Apps

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -304,13 +304,6 @@ exit 0
           -d "Unraid Connect plugin has been marked for removal. Please reboot your server to complete the uninstallation." \
           -i "warning"
         
-        # Remove the plugin file so it won't be installed on reboot
-        PLUGIN_FILE="/boot/config/plugins/${MAINNAME}.plg"
-        if [ -f "$PLUGIN_FILE" ]; then
-          echo "Removing plugin file: $PLUGIN_FILE"
-          rm -f "$PLUGIN_FILE"
-        fi
-        
         echo "Plugin marked for removal. Reboot required to complete uninstallation."
       else
         # Original removal method for older versions


### PR DESCRIPTION
Manual removal of the .plg is never necessary.  plugin script will automatically move the .plg to /config/plugins-removed

Manual removal results in PHP errors and possible indeterminate state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Updated plugin removal on Unraid 7.2+ to no longer delete the plugin file during boot. You’ll now be clearly prompted to reboot to complete uninstallation, reducing unexpected removals and improving guidance. Behavior on earlier Unraid versions remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->