### PR TITLE
fix: enhance activation code modal visibility logic

### DIFF
--- a/web/__test__/store/activationCodeModal.test.ts
+++ b/web/__test__/store/activationCodeModal.test.ts
@@ -25,6 +25,7 @@ describe('ActivationCodeModal Store', () => {
   let store: ReturnType<typeof useActivationCodeModalStore>;
   let mockIsHidden: ReturnType<typeof ref>;
   let mockIsFreshInstall: ReturnType<typeof ref>;
+  let mockActivationCode: ReturnType<typeof ref>;
   let mockCallbackData: ReturnType<typeof ref>;
 
   beforeEach(() => {
@@ -38,11 +39,13 @@ describe('ActivationCodeModal Store', () => {
 
     mockIsHidden = ref(null);
     mockIsFreshInstall = ref(false);
+    mockActivationCode = ref(null);
     mockCallbackData = ref(null);
 
     vi.mocked(useSessionStorage).mockReturnValue(mockIsHidden);
     vi.mocked(useActivationCodeDataStore).mockReturnValue({
       isFreshInstall: mockIsFreshInstall,
+      activationCode: mockActivationCode,
     } as unknown as ReturnType<typeof useActivationCodeDataStore>);
     vi.mocked(useCallbackActionsStore).mockReturnValue({
       callbackData: mockCallbackData,
@@ -56,6 +59,7 @@ describe('ActivationCodeModal Store', () => {
     vi.resetAllMocks();
     mockIsHidden.value = null;
     mockIsFreshInstall.value = false;
+    mockActivationCode.value = null;
     mockCallbackData.value = null;
   });
 
@@ -86,6 +90,7 @@ describe('ActivationCodeModal Store', () => {
     it('should be visible when fresh install and not explicitly hidden', () => {
       mockIsHidden.value = null;
       mockIsFreshInstall.value = true;
+      mockActivationCode.value = { code: '12345' };
       mockCallbackData.value = null;
 
       expect(store.isVisible).toBe(true);
@@ -104,9 +109,18 @@ describe('ActivationCodeModal Store', () => {
       expect(store.isVisible).toBe(false);
     });
 
+    it('should not be visible when activation code is missing', () => {
+      mockIsHidden.value = null;
+      mockIsFreshInstall.value = true;
+      mockActivationCode.value = null;
+
+      expect(store.isVisible).toBe(false);
+    });
+
     it('should not be visible when callback data exists', () => {
       mockIsHidden.value = null;
       mockIsFreshInstall.value = true;
+      mockActivationCode.value = { code: '12345' };
       mockCallbackData.value = { someData: 'test' };
 
       expect(store.isVisible).toBe(false);

--- a/web/src/components/Activation/store/activationCodeModal.ts
+++ b/web/src/components/Activation/store/activationCodeModal.ts
@@ -10,7 +10,7 @@ import { useCallbackActionsStore } from '~/store/callbackActions';
 export const useActivationCodeModalStore = defineStore('activationCodeModal', () => {
   const isHidden = useSessionStorage<boolean | null>(ACTIVATION_CODE_MODAL_HIDDEN_STORAGE_KEY, null);
 
-  const { isFreshInstall } = storeToRefs(useActivationCodeDataStore());
+  const { isFreshInstall, activationCode } = storeToRefs(useActivationCodeDataStore());
   const { callbackData } = storeToRefs(useCallbackActionsStore());
 
   const setIsHidden = (value: boolean | null) => {
@@ -30,8 +30,13 @@ export const useActivationCodeModalStore = defineStore('activationCodeModal', ()
     if (isHidden.value === false) {
       return true;
     }
-    // Default visibility logic (show if not explicitly hidden AND fresh install AND no callback data)
-    return isHidden.value === null && isFreshInstall.value && !callbackData.value;
+    // Default visibility logic (show if not explicitly hidden AND fresh install AND no callback data AND activation code is present)
+    return (
+      isHidden.value === null &&
+      isFreshInstall.value &&
+      !callbackData.value &&
+      Boolean(activationCode.value?.code)
+    );
   });
 
   /**


### PR DESCRIPTION
Updated the visibility logic in the activation code modal store to include a check for the presence of an activation code. The modal will now be shown if it is not explicitly hidden, the installation is fresh, there is no callback data, and an activation code is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activation modal visibility refined: it now appears only when an activation code is available, it’s a fresh install, the modal isn’t hidden, and there’s no callback data. Prevents unnecessary prompts.

* **Tests**
  * Expanded coverage to include activation code presence/absence and combined scenarios with fresh install and hidden states, ensuring accurate visibility logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->