### PR TITLE
chore(readme): add link to Deep Wiki for automated code documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@
 [![LinkedIn][linkedin-shield]][linkedin-url]
 [![Codecov][codecov-shield]][codecov-url]
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/unraid/api)
+
 </div>
 <!-- PROJECT LOGO -->
 <br />


### PR DESCRIPTION
Deep Wiki from Cognition Labs already has some useful documentation that they generated for us: https://deepwiki.com/unraid/api. This PR adds their badge to our readme so contributors can access their documentation directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added an “Ask DeepWiki” shield badge to the top of the README’s project shields, giving users quick access to a dedicated Q&A/help resource.
  - Improves discoverability of support and learning materials directly from the project homepage.
  - No functional or behavioral changes to the application; this is an informational enhancement aimed at easing onboarding and providing faster guidance for users exploring the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->