### PR TITLE
chore: decouple manual-release from release-production

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -31,6 +31,11 @@ on:
         type: string
         required: false
         description: "Git ref (commit SHA, branch, or tag) to checkout"
+      TRIGGER_PRODUCTION_RELEASE:
+        type: boolean
+        required: false
+        default: false
+        description: "Whether to automatically trigger the release-production workflow (default: false)"
     secrets:
       CF_ACCESS_KEY_ID:
         required: true
@@ -141,7 +146,7 @@ jobs:
           done  
 
       - name: Workflow Dispatch and wait
-        if: inputs.RELEASE_CREATED == 'true'
+        if: inputs.RELEASE_CREATED == 'true' && inputs.TRIGGER_PRODUCTION_RELEASE == true
         uses: the-actions-org/workflow-dispatch@v4.0.0
         with:
           workflow: release-production.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,6 +217,7 @@ jobs:
       BUCKET_PATH: unraid-api
       BASE_URL: "https://stable.dl.unraid.net/unraid-api"
       BUILD_NUMBER: ${{ needs.build-artifacts.outputs.build_number }}
+      TRIGGER_PRODUCTION_RELEASE: true
     secrets:
       CF_ACCESS_KEY_ID: ${{ secrets.CF_ACCESS_KEY_ID }}
       CF_SECRET_ACCESS_KEY: ${{ secrets.CF_SECRET_ACCESS_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to provide enhanced control over production release triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->