### PR TITLE
Guard connect plugin loading on plg presence

### DIFF
--- a/api/src/unraid-api/plugin/plugin.service.spec.ts
+++ b/api/src/unraid-api/plugin/plugin.service.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@app/unraid-api/config/api-config.module.js', () => ({
+    loadApiConfig: vi.fn(),
+}));
+
+vi.mock('@app/environment.js', () => ({
+    getPackageJson: vi.fn(),
+}));
+
+vi.mock('@app/core/utils/files/file-exists.js', () => ({
+    fileExists: vi.fn(),
+}));
+
+const { loadApiConfig } = await import('@app/unraid-api/config/api-config.module.js');
+const { getPackageJson } = await import('@app/environment.js');
+const { fileExists } = await import('@app/core/utils/files/file-exists.js');
+const { PluginService } = await import('./plugin.service.js');
+
+const CONNECT_PACKAGE = 'unraid-api-plugin-connect';
+
+describe('PluginService.listPlugins', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        Reflect.set(PluginService, 'plugins', undefined);
+    });
+
+    it('skips connect plugin when no .plg file is present', async () => {
+        vi.mocked(loadApiConfig).mockResolvedValue({ plugins: [CONNECT_PACKAGE] } as any);
+        vi.mocked(getPackageJson).mockReturnValue({
+            peerDependencies: {
+                [CONNECT_PACKAGE]: '1.0.0',
+                'unraid-api-plugin-example': '1.0.0',
+            },
+        } as any);
+        vi.mocked(fileExists).mockResolvedValue(false);
+
+        const plugins = await PluginService.listPlugins();
+
+        expect(plugins).toEqual([]);
+        expect(vi.mocked(fileExists)).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps connect plugin when a .plg file exists', async () => {
+        vi.mocked(loadApiConfig).mockResolvedValue({ plugins: [CONNECT_PACKAGE] } as any);
+        vi.mocked(getPackageJson).mockReturnValue({
+            peerDependencies: {
+                [CONNECT_PACKAGE]: '1.0.0',
+                'unraid-api-plugin-example': '1.0.0',
+            },
+        } as any);
+        vi.mocked(fileExists).mockImplementation(async (path) => path.endsWith('.plg'));
+
+        const plugins = await PluginService.listPlugins();
+
+        expect(plugins).toEqual([[CONNECT_PACKAGE, '1.0.0']]);
+        expect(vi.mocked(fileExists)).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- check for dynamix.unraid.net plugin .plg files before registering the Connect API plugin
- add unit coverage for plugin discovery when the Connect .plg is missing or present

## Testing
- pnpm --filter @unraid/api exec vitest run src/unraid-api/plugin/plugin.service.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691414f39b848323b1fc0f0c508e3f38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for plugin service to validate detection logic under various scenarios, including when plugins are and are not installed.

* **Bug Fixes**
  * Enhanced plugin system to verify actual installation status on disk before reporting plugins as available; plugins without proper installation markers are now filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->