### PR TITLE
fix: allow docs iframes to load credentialless

### DIFF
--- a/web/src/components/ReleaseNotesModal.vue
+++ b/web/src/components/ReleaseNotesModal.vue
@@ -61,7 +61,8 @@ const handleClose = () => {
             ref="iframeRef"
             :src="releaseNotesUrl"
             class="h-full w-full rounded-md border-0"
-            sandbox="allow-scripts allow-same-origin"
+            credentialless
+            sandbox="allow-scripts"
             title="Unraid Release Notes"
             @load="handleIframeLoad"
           />

--- a/web/src/components/UpdateOs/ChangelogModal.vue
+++ b/web/src/components/UpdateOs/ChangelogModal.vue
@@ -160,7 +160,8 @@ const showRawChangelog = computed<boolean>(() => {
           <iframe
             :src="iframeSrc"
             class="h-full w-full rounded-md border-0"
-            sandbox="allow-scripts allow-same-origin"
+            credentialless
+            sandbox="allow-scripts"
             allow="fullscreen"
             referrerpolicy="no-referrer"
             title="Unraid Changelog"


### PR DESCRIPTION
## Summary
- mark the changelog and release notes iframes as credentialless so Firefox can embed docs.unraid.net without COEP errors

## Testing
- pnpm --filter web lint:eslint
- pnpm --filter web exec -- prettier --check src/components/ReleaseNotesModal.vue src/components/UpdateOs/ChangelogModal.vue

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69156d3a5d5c832388e40b8567561fda)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security configuration for modals to enhance stability and strengthen credential protection during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->