### PR TITLE
Use persisted state plugin for theme store

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,6 +1154,9 @@ importers:
       pinia:
         specifier: 3.0.3
         version: 3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2))
+      pinia-plugin-persistedstate:
+        specifier: 4.7.1
+        version: 4.7.1(@nuxt/kit@4.0.3(magicast@0.3.5))(pinia@3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2)))
       postcss-import:
         specifier: 16.1.1
         version: 16.1.1(postcss@8.5.6)
@@ -10089,6 +10092,20 @@ packages:
   pify@6.1.0:
     resolution: {integrity: sha512-KocF8ve28eFjjuBKKGvzOBGzG8ew2OqOOSxTTZhirkzH7h3BI1vyzqlR0qbfcDBve1Yzo3FVlWUAtCRrbVN8Fw==}
     engines: {node: '>=14.16'}
+
+  pinia-plugin-persistedstate@4.7.1:
+    resolution: {integrity: sha512-WHOqh2esDlR3eAaknPbqXrkkj0D24h8shrDPqysgCFR6ghqP/fpFfJmMPJp0gETHsvrh9YNNg6dQfo2OEtDnIQ==}
+    peerDependencies:
+      '@nuxt/kit': '>=3.0.0'
+      '@pinia/nuxt': '>=0.10.0'
+      pinia: '>=3.0.0'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@pinia/nuxt':
+        optional: true
+      pinia:
+        optional: true
 
   pinia@3.0.3:
     resolution: {integrity: sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==}
@@ -22703,6 +22720,13 @@ snapshots:
   pify@3.0.0: {}
 
   pify@6.1.0: {}
+
+  pinia-plugin-persistedstate@4.7.1(@nuxt/kit@4.0.3(magicast@0.3.5))(pinia@3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2))):
+    dependencies:
+      defu: 6.1.4
+    optionalDependencies:
+      '@nuxt/kit': 4.0.3(magicast@0.3.5)
+      pinia: 3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2))
 
   pinia@3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2)):
     dependencies:

--- a/web/__test__/store/theme.test.ts
+++ b/web/__test__/store/theme.test.ts
@@ -3,13 +3,16 @@
  */
 
 import { nextTick, ref } from 'vue';
-import { createPinia, setActivePinia } from 'pinia';
+import { setActivePinia } from 'pinia';
 
 import { defaultColors } from '~/themes/default';
 import hexToRgba from 'hex-to-rgba';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useThemeStore } from '~/store/theme';
+import type { Theme } from '~/themes/types';
+
+import { globalPinia } from '~/store/globalPinia';
+import { THEME_STORAGE_KEY, useThemeStore } from '~/store/theme';
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: () => ({
@@ -25,15 +28,19 @@ vi.mock('hex-to-rgba', () => ({
 }));
 
 describe('Theme Store', () => {
-  let store: ReturnType<typeof useThemeStore>;
   const originalAddClassFn = document.body.classList.add;
   const originalRemoveClassFn = document.body.classList.remove;
   const originalStyleCssText = document.body.style.cssText;
   const originalDocumentElementSetProperty = document.documentElement.style.setProperty;
+  const originalDocumentElementAddClass = document.documentElement.classList.add;
+  const originalDocumentElementRemoveClass = document.documentElement.classList.remove;
+
+  let store: ReturnType<typeof useThemeStore> | undefined;
 
   beforeEach(() => {
-    setActivePinia(createPinia());
-    store = useThemeStore();
+    setActivePinia(globalPinia);
+    store = undefined;
+    window.localStorage.clear();
 
     document.body.classList.add = vi.fn();
     document.body.classList.remove = vi.fn();
@@ -51,16 +58,32 @@ describe('Theme Store', () => {
   });
 
   afterEach(() => {
-    // Restore original methods
+    store?.$dispose();
+    store = undefined;
+
     document.body.classList.add = originalAddClassFn;
     document.body.classList.remove = originalRemoveClassFn;
     document.body.style.cssText = originalStyleCssText;
     document.documentElement.style.setProperty = originalDocumentElementSetProperty;
+    document.documentElement.classList.add = originalDocumentElementAddClass;
+    document.documentElement.classList.remove = originalDocumentElementRemoveClass;
     vi.restoreAllMocks();
   });
 
+  const createStore = () => {
+    if (!store) {
+      store = useThemeStore(globalPinia);
+    }
+
+    return store;
+  };
+
   describe('State and Initialization', () => {
     it('should initialize with default theme', () => {
+      const store = createStore();
+
+      expect(typeof store.$persist).toBe('function');
+
       expect(store.theme).toEqual({
         name: 'white',
         banner: false,
@@ -74,6 +97,8 @@ describe('Theme Store', () => {
     });
 
     it('should compute darkMode correctly', () => {
+      const store = createStore();
+
       expect(store.darkMode).toBe(false);
 
       store.setTheme({ ...store.theme, name: 'black' });
@@ -87,6 +112,8 @@ describe('Theme Store', () => {
     });
 
     it('should compute bannerGradient correctly', () => {
+      const store = createStore();
+
       expect(store.bannerGradient).toBeUndefined();
 
       store.setTheme({
@@ -112,6 +139,8 @@ describe('Theme Store', () => {
 
   describe('Actions', () => {
     it('should set theme correctly', () => {
+      const store = createStore();
+
       const newTheme = {
         name: 'black',
         banner: true,
@@ -127,6 +156,8 @@ describe('Theme Store', () => {
     });
 
     it('should update body classes for dark mode', async () => {
+      const store = createStore();
+
       store.setTheme({ ...store.theme, name: 'black' });
 
       await nextTick();
@@ -141,6 +172,8 @@ describe('Theme Store', () => {
     });
 
     it('should update activeColorVariables when theme changes', async () => {
+      const store = createStore();
+
       store.setTheme({
         ...store.theme,
         name: 'white',
@@ -170,6 +203,7 @@ describe('Theme Store', () => {
     });
 
     it('should handle banner gradient correctly', async () => {
+      const store = createStore();
       const mockHexToRgba = vi.mocked(hexToRgba);
 
       mockHexToRgba.mockClear();
@@ -198,6 +232,45 @@ describe('Theme Store', () => {
       expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
         '--banner-gradient',
         'linear-gradient(90deg, rgba(mock-#112233-0) 0, rgba(mock-#112233-0.7) 90%)'
+      );
+    });
+
+    it('should hydrate theme from cache when available', () => {
+      const cachedTheme = {
+        name: 'black',
+        banner: true,
+        bannerGradient: false,
+        bgColor: '#222222',
+        descriptionShow: true,
+        metaColor: '#aaaaaa',
+        textColor: '#ffffff',
+      } satisfies Theme;
+
+      window.localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify({ theme: cachedTheme }));
+
+      const store = createStore();
+
+      expect(store.theme).toEqual(cachedTheme);
+    });
+
+    it('should persist server theme responses to cache', async () => {
+      const store = createStore();
+
+      const serverTheme = {
+        name: 'gray',
+        banner: false,
+        bannerGradient: false,
+        bgColor: '#111111',
+        descriptionShow: false,
+        metaColor: '#999999',
+        textColor: '#eeeeee',
+      } satisfies Theme;
+
+      store.setTheme(serverTheme, { source: 'server' });
+      await nextTick();
+
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toEqual(
+        JSON.stringify({ theme: serverTheme })
       );
     });
   });

--- a/web/package.json
+++ b/web/package.json
@@ -129,6 +129,7 @@
     "marked": "16.2.1",
     "marked-base-url": "1.1.7",
     "pinia": "3.0.3",
+    "pinia-plugin-persistedstate": "4.7.1",
     "postcss-import": "16.1.1",
     "semver": "7.7.2",
     "tailwind-merge": "2.6.0",


### PR DESCRIPTION
## Summary
- add pinia-plugin-persistedstate to the web package and remove the bespoke persisted state helper
- wire the theme store to hydrate/persist using pinia-plugin-persistedstate while sanitizing cached data
- update the theme store unit tests to run against the shared Pinia instance and assert persistence

## Testing
- pnpm --filter web test __test__/store/theme.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69156c5e8de48323841f7dbfdadec51d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Theme preferences are now saved and restored across browser sessions, automatically preserving your selected theme when you return to the app.

* **Tests**
  * Enhanced test coverage for theme persistence and state hydration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->