### PR TITLE
feat: Refine JSONForms translation fallback

### DIFF
--- a/web/src/__tests__/jsonforms-i18n.spec.ts
+++ b/web/src/__tests__/jsonforms-i18n.spec.ts
@@ -1,0 +1,101 @@
+import { defineComponent, ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { mount } from '@vue/test-utils';
+
+import { createAjv } from '@jsonforms/core';
+import { JsonForms } from '@jsonforms/vue';
+import { vanillaRenderers } from '@jsonforms/vue-vanilla';
+import { useJsonFormsI18n } from '~/helpers/jsonforms-i18n';
+import { describe, expect, it } from 'vitest';
+
+describe('useJsonFormsI18n', () => {
+  const buildWrapper = (messages: Record<string, string>) => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: messages },
+    });
+
+    let jsonFormsI18nReturn: ReturnType<typeof useJsonFormsI18n> | undefined;
+    const Harness = defineComponent({
+      setup() {
+        jsonFormsI18nReturn = useJsonFormsI18n();
+        return () => null;
+      },
+    });
+
+    const wrapper = mount(Harness, { global: { plugins: [i18n] } });
+    if (!jsonFormsI18nReturn) {
+      throw new Error('useJsonFormsI18n did not provide a value');
+    }
+    return { wrapper, jsonFormsI18n: jsonFormsI18nReturn };
+  };
+
+  it('falls back between common suffixes when translating', () => {
+    const { wrapper, jsonFormsI18n } = buildWrapper({
+      'jsonforms.sample.fallback.label': 'Label fallback',
+      'jsonforms.sample.base': 'Base fallback',
+    });
+
+    const translator = jsonFormsI18n.value.translate;
+
+    expect(translator('jsonforms.sample.fallback.text', undefined)).toBe('Label fallback');
+    expect(translator('jsonforms.sample.base.label', undefined)).toBe('Base fallback');
+    expect(translator('jsonforms.sample.fallback', undefined)).toBe('Label fallback');
+    expect(translator('jsonforms.missing.value', 'Default')).toBe('Default');
+    wrapper.unmount();
+  });
+
+  it('translates label elements rendered by JsonForms', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: {
+        en: {
+          'jsonforms.sample.name.label': 'Localized label',
+        },
+      },
+    });
+
+    const schema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          i18n: 'jsonforms.sample.name',
+        },
+      },
+    };
+
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Label', text: 'Name', i18n: 'jsonforms.sample.name' },
+        { type: 'Control', scope: '#/properties/name', i18n: 'jsonforms.sample.name' },
+      ],
+    };
+
+    const FormHarness = defineComponent({
+      components: { JsonForms },
+      setup() {
+        const data = ref({});
+        const jsonFormsI18n = useJsonFormsI18n();
+        return {
+          schema,
+          uiSchema,
+          data,
+          renderers: vanillaRenderers,
+          ajv: createAjv(),
+          jsonFormsI18n,
+        };
+      },
+      template:
+        '<JsonForms :schema="schema" :uischema="uiSchema" :data="data" :renderers="renderers" :ajv="ajv" :i18n="jsonFormsI18n" />',
+    });
+
+    const wrapper = mount(FormHarness, { global: { plugins: [i18n] } });
+
+    expect(wrapper.text()).toContain('Localized label');
+    wrapper.unmount();
+  });
+});

--- a/web/src/components/ApiKey/ApiKeyCreate.vue
+++ b/web/src/components/ApiKey/ApiKeyCreate.vue
@@ -10,8 +10,6 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
-  jsonFormsAjv,
-  jsonFormsRenderers,
   ResponsiveModal,
   ResponsiveModalFooter,
   ResponsiveModalHeader,
@@ -19,7 +17,6 @@ import {
 } from '@unraid/ui';
 import { JsonForms } from '@jsonforms/vue';
 import { extractGraphQLErrorMessage } from '~/helpers/functions';
-import { useJsonFormsI18n } from '~/helpers/jsonforms-i18n';
 
 import type { ApolloError } from '@apollo/client/errors';
 import type { FragmentType } from '~/composables/gql/fragment-masking';
@@ -41,6 +38,7 @@ import EffectivePermissions from '~/components/ApiKey/EffectivePermissions.vue';
 import { useFragment } from '~/composables/gql/fragment-masking';
 import { useApiKeyPermissionPresets } from '~/composables/useApiKeyPermissionPresets';
 import { useClipboardWithToast } from '~/composables/useClipboardWithToast';
+import { useJsonFormsDefaults } from '~/composables/useJsonFormsDefaults';
 import { useApiKeyStore } from '~/store/apiKey';
 
 interface Props {
@@ -104,7 +102,12 @@ const formData = ref<FormData>({
   roles: [],
 } as FormData);
 const formValid = ref(false);
-const jsonFormsI18n = useJsonFormsI18n();
+const {
+  ajv: jsonFormsAjv,
+  config: jsonFormsConfig,
+  renderers,
+  i18n: jsonFormsI18n,
+} = useJsonFormsDefaults();
 
 // Use clipboard for copying
 const { copyWithNotification, copied } = useClipboardWithToast();
@@ -464,8 +467,9 @@ const copyApiKey = async () => {
         <JsonForms
           :schema="formSchema.dataSchema"
           :uischema="formSchema.uiSchema"
-          :renderers="jsonFormsRenderers"
+          :renderers="renderers"
           :data="formData"
+          :config="jsonFormsConfig"
           :ajv="jsonFormsAjv"
           :i18n="jsonFormsI18n"
           @change="

--- a/web/src/components/ConnectSettings/ConnectSettings.standalone.vue
+++ b/web/src/components/ConnectSettings/ConnectSettings.standalone.vue
@@ -5,9 +5,8 @@ import { storeToRefs } from 'pinia';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import { watchDebounced } from '@vueuse/core';
 
-import { BrandButton, jsonFormsAjv, jsonFormsRenderers, Label, SettingsGrid } from '@unraid/ui';
+import { BrandButton, Label, SettingsGrid } from '@unraid/ui';
 import { JsonForms } from '@jsonforms/vue';
-import { useJsonFormsI18n } from '~/helpers/jsonforms-i18n';
 
 import Auth from '~/components/Auth.standalone.vue';
 // unified settings values are returned as JSON, so use a generic record type
@@ -19,6 +18,7 @@ import {
 } from '~/components/ConnectSettings/graphql/settings.query';
 import OidcDebugLogs from '~/components/ConnectSettings/OidcDebugLogs.vue';
 import DownloadApiLogs from '~/components/DownloadApiLogs.standalone.vue';
+import { useJsonFormsDefaults } from '~/composables/useJsonFormsDefaults';
 import { useServerStore } from '~/store/server';
 
 // Disable automatic attribute inheritance
@@ -86,13 +86,12 @@ onMutateSettingsDone((result) => {
  *     Form Config & Actions
  *---------------------------------------------**/
 
-const jsonFormsConfig = {
-  restrict: false,
-  trim: false,
-};
-
-const renderers = [...jsonFormsRenderers];
-const jsonFormsI18n = useJsonFormsI18n();
+const {
+  ajv: jsonFormsAjv,
+  config: jsonFormsConfig,
+  renderers,
+  i18n: jsonFormsI18n,
+} = useJsonFormsDefaults();
 
 /** Called when the user clicks the "Apply" button */
 const submitSettingsUpdate = async () => {

--- a/web/src/composables/useJsonFormsDefaults.ts
+++ b/web/src/composables/useJsonFormsDefaults.ts
@@ -1,0 +1,21 @@
+import { computed } from 'vue';
+
+import { jsonFormsAjv, jsonFormsRenderers } from '@unraid/ui';
+import { useJsonFormsI18n } from '~/helpers/jsonforms-i18n';
+
+const defaultConfig = Object.freeze({
+  restrict: false,
+  trim: false,
+});
+
+export function useJsonFormsDefaults() {
+  const i18n = useJsonFormsI18n();
+  const renderers = computed(() => [...jsonFormsRenderers]);
+
+  return {
+    ajv: jsonFormsAjv,
+    config: defaultConfig,
+    i18n,
+    renderers,
+  } as const;
+}

--- a/web/vitest.jsonforms.config.ts
+++ b/web/vitest.jsonforms.config.ts
@@ -1,0 +1,9 @@
+import baseConfig from './vitest.config';
+import { mergeConfig } from 'vitest/config';
+
+export default mergeConfig(baseConfig, {
+  test: {
+    include: ['src/__tests__/jsonforms-i18n.spec.ts'],
+    maxWorkers: 1,
+  },
+});


### PR DESCRIPTION
## Summary
- expand the JSONForms i18n helper to derive candidate keys in both suffix directions and rely on Vue i18n fallbacks instead of duplicate locale entries
- remove redundant `.text` keys from all locale files now that fallback coverage exists and realign the focused Vitest harness to assert the new behavior
- point the JSONForms vitest config at the local base config so the suite can execute without alias resolution issues

## Testing
- pnpm vitest run src/__tests__/jsonforms-i18n.spec.ts --config vitest.jsonforms.config.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68faf98cb39483238b1db61aa3e6106a)