### PR TITLE
chore: remove fetch-depth limit in release-please git checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - id: release
         uses: googleapis/release-please-action@v4


### PR DESCRIPTION
Hopefully fixes release please over-scoping its changelog generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enable full repository history retrieval during build processes, improving the reliability of version control operations in automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->