### PR TITLE
fix: resolve header flash for background color

### DIFF
--- a/web/src/store/theme.ts
+++ b/web/src/store/theme.ts
@@ -341,6 +341,7 @@ export const useThemeStore = defineStore(
       afterHydrate: (ctx) => {
         const store = ctx.store as ReturnType<typeof useThemeStore>;
         store.setTheme(store.theme);
+        store.setCssVars();
       },
     },
   }


### PR DESCRIPTION
## Summary
- rely on the existing Pinia persisted state instead of manual localStorage hydration
- reapply CSS variables after persisted hydration so custom header colors show immediately

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5a1d052c8323973847eb5833fbb9)