### PR TITLE
chore: for releases, use tag as source of truth for versioning

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -78,7 +78,21 @@ jobs:
           GIT_SHA=$(git rev-parse --short HEAD)
           IS_TAGGED=$(git describe --tags --abbrev=0 --exact-match || echo '')
           PACKAGE_LOCK_VERSION=$(jq -r '.version' package.json)
-          API_VERSION=$([[ -n "$IS_TAGGED" ]] && echo "$PACKAGE_LOCK_VERSION" || echo "${PACKAGE_LOCK_VERSION}+${GIT_SHA}")
+          
+          # For release builds, trust the release tag version to avoid stale checkouts
+          if [ "${{ inputs.RELEASE_CREATED }}" = "true" ] && [ -n "${{ inputs.RELEASE_TAG }}" ]; then
+            TAG_VERSION="${{ inputs.RELEASE_TAG }}"
+            TAG_VERSION="${TAG_VERSION#v}" # trim leading v if present
+
+            if [ "$TAG_VERSION" != "$PACKAGE_LOCK_VERSION" ]; then
+              echo "::warning::Release tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_LOCK_VERSION). Using tag version for TXZ naming."
+            fi
+
+            API_VERSION="$TAG_VERSION"
+          else
+            API_VERSION=$([[ -n "$IS_TAGGED" ]] && echo "$PACKAGE_LOCK_VERSION" || echo "${PACKAGE_LOCK_VERSION}+${GIT_SHA}")
+          fi
+
           echo "API_VERSION=${API_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies


### PR DESCRIPTION
@elibosley this is what Codex came up with re: the versioning mismatch for 4.27.1 yesterday

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow with release-aware versioning logic. Version management now automatically adapts based on release status, utilizing release tags when available and maintaining backward compatibility for standard builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->