### PR TITLE
Handle build number generation on forks

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build API
     runs-on: ubuntu-latest
     outputs:
-      build_number: ${{ steps.buildnumber.outputs.build_number }}
+      build_number: ${{ steps.buildnumber.outputs.build_number || steps.fallback_buildnumber.outputs.build_number }}
     defaults:
       run:
         working-directory: api
@@ -81,10 +81,17 @@ jobs:
 
       - name: Generate build number
         id: buildnumber
+        if: github.repository == 'unraid/api'
+        continue-on-error: true
         uses: onyxmueller/build-tag-number@v1
         with:
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
           prefix: ${{ inputs.version_override || steps.vars.outputs.PACKAGE_LOCK_VERSION }}
+
+      - name: Generate fallback build number
+        id: fallback_buildnumber
+        if: steps.buildnumber.outcome != 'success'
+        run: echo "build_number=${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
- guard build number generation to the main repository and allow failures without stopping the workflow
- add a fallback build number derived from the GitHub run number when the tag-based number cannot be created

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693894fb808c8323a3ee51e47fe5d772)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline reliability with enhanced fallback mechanisms to ensure consistent artifact generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->