### PR TITLE
fix(plg): explicitly stop an existing api before installation

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -478,6 +478,12 @@ if [ "$SKIP_API_INSTALL" = false ]; then
     fi
   done
 
+  # Stop the API service before mutating /usr/local/unraid-api to avoid upgrade races
+  if [ -x "/etc/rc.d/rc.unraid-api" ]; then
+    echo "Stopping Unraid API service before upgrade..."
+    /etc/rc.d/rc.unraid-api stop || echo "Warning: Failed to stop Unraid API service"
+  fi
+
   # Remove existing node_modules directory
   echo "Cleaning up existing node_modules directory..."
   if [ -d "/usr/local/unraid-api/node_modules" ]; then


### PR DESCRIPTION
Necessary for "clean" upgrades to api orchestration (eg changing how the api is daemonized).

Prior to this, `rc.unraid-api start` would also restart a running api, which sufficed for application updates, but is insufficient for orchestration updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update reliability by ensuring services are properly stopped before system modifications occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->