### PR TITLE
chore(ci): run release please before other jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,32 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: release
+        uses: googleapis/release-please-action@v4
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created || 'false' }}
+      tag_name: ${{ steps.release.outputs.tag_name || '' }}
+
   test-api:
     name: Test API
     defaults:
       run:
         working-directory: api
     runs-on: ubuntu-latest
+    needs: release-please
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -164,32 +184,10 @@ jobs:
       VITE_CALLBACK_KEY: ${{ secrets.VITE_CALLBACK_KEY }}
       UNRAID_BOT_GITHUB_ADMIN_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN }}
 
-  release-please:
-    name: Release Please
-    runs-on: ubuntu-latest
-    # Only run on pushes to main AND after tests pass
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs:
-      - test-api
-      - build-artifacts
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - id: release
-        uses: googleapis/release-please-action@v4
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created || 'false' }}
-      tag_name: ${{ steps.release.outputs.tag_name || '' }}
-
   build-plugin-staging-pr:
     name: Build and Deploy Plugin
     needs:
+      - release-please
       - build-artifacts
       - test-api
     uses: ./.github/workflows/build-plugin.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,6 @@ jobs:
   build-plugin-staging-pr:
     name: Build and Deploy Plugin
     needs:
-      - release-please
       - build-artifacts
       - test-api
     uses: ./.github/workflows/build-plugin.yml


### PR DESCRIPTION
…cess

- Moved the 'release-please' job to run independently and added it as a dependency for the 'test-api' and 'build-plugin-staging-pr' jobs.
- Updated permissions and checkout steps for the 'release-please' job to ensure proper execution on main branch pushes.
- Enhanced workflow structure for better clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration for improved release management workflow execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->