### PR TITLE
fix: handle race condition between guid loading and license check

### DIFF
--- a/web/src/components/Registration/ReplaceCheck.vue
+++ b/web/src/components/Registration/ReplaceCheck.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 
-import { ArrowTopRightOnSquareIcon, KeyIcon } from '@heroicons/vue/24/solid';
+import { ArrowPathIcon, ArrowTopRightOnSquareIcon, KeyIcon } from '@heroicons/vue/24/solid';
 import { Badge, BrandButton } from '@unraid/ui';
 import { DOCS_REGISTRATION_REPLACE_KEY } from '~/helpers/urls';
 
@@ -11,20 +12,30 @@ import { useReplaceRenewStore } from '~/store/replaceRenew';
 const { t } = useI18n();
 const replaceRenewStore = useReplaceRenewStore();
 const { replaceStatusOutput } = storeToRefs(replaceRenewStore);
+
+const isError = computed(() => replaceStatusOutput.value?.variant === 'red');
+const showButton = computed(() => !replaceStatusOutput.value || isError.value);
+
+const handleCheck = () => {
+  if (isError.value) {
+    replaceRenewStore.reset();
+  }
+  replaceRenewStore.check(true);
+};
 </script>
 
 <template>
   <div class="flex flex-wrap items-center justify-between gap-2">
     <BrandButton
-      v-if="!replaceStatusOutput"
-      :icon="KeyIcon"
-      :text="t('registration.replaceCheck.checkEligibility')"
+      v-if="showButton"
+      :icon="isError ? ArrowPathIcon : KeyIcon"
+      :text="isError ? t('common.retry') : t('registration.replaceCheck.checkEligibility')"
       class="grow"
-      @click="replaceRenewStore.check"
+      @click="handleCheck"
     />
 
-    <Badge v-else :variant="replaceStatusOutput.variant" :icon="replaceStatusOutput.icon" size="md">
-      {{ t(replaceStatusOutput.text ?? 'Unknown') }}
+    <Badge v-else :variant="replaceStatusOutput?.variant" :icon="replaceStatusOutput?.icon" size="md">
+      {{ t(replaceStatusOutput?.text ?? 'Unknown') }}
     </Badge>
 
     <span class="inline-flex flex-wrap items-center justify-end gap-2">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -30,6 +30,7 @@
   "common.installed": "Installed",
   "common.installing": "Installing",
   "common.learnMore": "Learn More",
+  "common.retry": "Retry",
   "common.loading2": "Loading…",
   "common.success": "Success!",
   "common.unknown": "Unknown",


### PR DESCRIPTION
On errors, a `console.error` message should be emitted from the browser console, tagged `[ReplaceCheck.check]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry capability for license eligibility checks with a contextual "Retry" button that appears in error states.

* **Bug Fixes**
  * Fixed license status initialization to correctly default to ready state.
  * Enhanced error messaging with specific messages for different failure scenarios (missing credentials, access denied, server errors).
  * Improved status display handling to prevent potential runtime errors.

* **Localization**
  * Added "Retry" text translation.

* **Tests**
  * Updated and added tests for reset functionality and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->