### PR TITLE
fix: unraid-connect plugin not loaded when connect is installed

### DIFF
--- a/api/src/unraid-api/plugin/plugin.service.ts
+++ b/api/src/unraid-api/plugin/plugin.service.ts
@@ -91,13 +91,9 @@ export class PluginService {
                 return name;
             })
         );
-        const { peerDependencies } = getPackageJson();
-        // All api plugins must be installed as peer dependencies of the unraid-api package
-        if (!peerDependencies) {
-            PluginService.logger.warn('Unraid-API peer dependencies not found; skipping plugins.');
-            return [];
-        }
-        const pluginTuples = Object.entries(peerDependencies).filter(
+        const { peerDependencies = {}, dependencies = {} } = getPackageJson();
+        const allDependencies = { ...peerDependencies, ...dependencies };
+        const pluginTuples = Object.entries(allDependencies).filter(
             (entry): entry is [string, string] => {
                 const [pkgName, version] = entry;
                 return pluginNames.has(pkgName) && typeof version === 'string';


### PR DESCRIPTION
Previously, api plugins could only be installed as `peerDependencies` in the api. This change allows them to be listed as `dependencies` as well. This makes plugin loading (eg loading Connect) more robust.

Tests:

- [x] Re-logging on 7.3.0-beta.0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin discovery now evaluates both regular and peer dependencies instead of relying exclusively on peer dependencies, enabling detection across broader dependency configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->