### PR TITLE
fix(docker): change "visit" to "webui" & use correct link

### DIFF
--- a/web/src/components/Docker/ContainerOverviewCard.vue
+++ b/web/src/components/Docker/ContainerOverviewCard.vue
@@ -11,7 +11,7 @@ import {
   formatNetwork,
   formatUptime,
   formatVolumes,
-  getFirstLanIp,
+  getWebUiUrl,
   openLanIpInNewTab,
   stripLeadingSlash,
 } from '@/utils/docker';
@@ -77,7 +77,7 @@ const projectUrl = computed(() => props.container?.projectUrl || null);
 const registryUrl = computed(() => props.container?.registryUrl || null);
 const supportUrl = computed(() => props.container?.supportUrl || null);
 
-const lanIpAddress = computed(() => getFirstLanIp(props.container));
+const webUiAddress = computed(() => getWebUiUrl(props.container));
 
 const isTailscaleEnabled = computed(() => Boolean(props.container?.tailscaleEnabled));
 const isContainerRunning = computed(() => props.container?.state === 'RUNNING');
@@ -127,8 +127,8 @@ function formatTailscaleDate(dateStr: string | Date | null | undefined): string 
 }
 
 function handleOpenWebUI() {
-  if (lanIpAddress.value) {
-    openLanIpInNewTab(lanIpAddress.value);
+  if (webUiAddress.value) {
+    openLanIpInNewTab(webUiAddress.value);
   }
 }
 
@@ -204,14 +204,14 @@ function handleOpenTailscaleAuth() {
 
         <div class="flex shrink-0 items-center gap-2">
           <UButton
-            v-if="lanIpAddress"
+            v-if="webUiAddress"
             size="sm"
             variant="soft"
             color="primary"
             icon="i-lucide-external-link"
             @click="handleOpenWebUI"
           >
-            Web UI
+            WebUI
           </UButton>
           <UButton
             v-if="tailscaleStatus?.webUiUrl"
@@ -221,7 +221,7 @@ function handleOpenTailscaleAuth() {
             icon="i-lucide-external-link"
             @click="handleOpenTailscaleWebUI"
           >
-            Web UI (Tailscale)
+            WebUI (Tailscale)
           </UButton>
         </div>
       </div>

--- a/web/src/components/LayoutViews/Card/CardItem.vue
+++ b/web/src/components/LayoutViews/Card/CardItem.vue
@@ -117,7 +117,7 @@ const handleToggleRunning = () => {
           <!-- Action Buttons - only visible on hover -->
           <div class="hidden items-center gap-2 group-hover:flex">
             <UButton color="primary" variant="outline" size="sm" @click.stop> Manage </UButton>
-            <UButton color="primary" variant="solid" size="sm" @click.stop> Visit </UButton>
+            <UButton color="primary" variant="solid" size="sm" @click.stop> WebUI </UButton>
           </div>
 
           <!-- Autostart Toggle - only visible on hover -->

--- a/web/src/composables/useDockerRowActions.ts
+++ b/web/src/composables/useDockerRowActions.ts
@@ -133,7 +133,7 @@ export function useDockerRowActions(options: DockerRowActionsOptions) {
 
     if (canVisit && webUiUrl) {
       quickActions.push({
-        label: 'Visit',
+        label: 'WebUI',
         icon: 'i-lucide-external-link',
         as: 'button',
         onSelect: () => openLanIpInNewTab(webUiUrl),
@@ -143,7 +143,7 @@ export function useDockerRowActions(options: DockerRowActionsOptions) {
     if (hasTailscale && row.meta?.id) {
       const containerId = row.meta.id;
       quickActions.push({
-        label: 'Visit (Tailscale)',
+        label: 'WebUI (Tailscale)',
         icon: 'i-lucide-external-link',
         as: 'button',
         onSelect: () => onVisitTailscale(containerId),


### PR DESCRIPTION
## Summary

  - Rename "Visit" buttons to "WebUI" for consistent terminology across Docker container UI
  - Use getWebUiUrl instead of getFirstLanIp to display the correct WebUI link

## Test plan
- [x] Verify Docker containers with a WebUI show the "WebUI" button
- [x] Clicking "WebUI" opens the correct URL in a new tab
- [x] "WebUI (Tailscale)" button appears for Tailscale-enabled containers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button and action labels across Docker container interface. Changed "Visit" to "WebUI" and "Web UI" to "WebUI" for consistent naming in container actions and Tailscale variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->