### PR TITLE
fix(docker): remove aggressive caching to ensure data correctness

### DIFF
--- a/api/src/unraid-api/graph/resolvers/docker/docker-event.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-event.service.spec.ts
@@ -61,7 +61,6 @@ vi.mock('./utils/docker-client.js', () => ({
 vi.mock('./docker.service.js', () => ({
     DockerService: vi.fn().mockImplementation(() => ({
         getDockerClient: vi.fn(),
-        clearContainerCache: vi.fn(),
         getAppInfo: vi.fn().mockResolvedValue({ info: { apps: { installed: 1, running: 1 } } }),
     })),
 }));
@@ -76,7 +75,6 @@ describe('DockerEventService', () => {
         // Create a mock Docker service *instance*
         const mockDockerServiceImpl = {
             getDockerClient: vi.fn(),
-            clearContainerCache: vi.fn(),
             getAppInfo: vi.fn().mockResolvedValue({ info: { apps: { installed: 1, running: 1 } } }),
         };
 
@@ -132,7 +130,6 @@ describe('DockerEventService', () => {
 
         await waitForEventProcessing();
 
-        expect(dockerService.clearContainerCache).toHaveBeenCalled();
         expect(dockerService.getAppInfo).toHaveBeenCalled();
         expect(pubsub.publish).toHaveBeenCalledWith(PUBSUB_CHANNEL.INFO, expect.any(Object));
     });
@@ -154,7 +151,6 @@ describe('DockerEventService', () => {
 
         await waitForEventProcessing();
 
-        expect(dockerService.clearContainerCache).not.toHaveBeenCalled();
         expect(dockerService.getAppInfo).not.toHaveBeenCalled();
         expect(pubsub.publish).not.toHaveBeenCalled();
     });
@@ -172,7 +168,6 @@ describe('DockerEventService', () => {
         await waitForEventProcessing();
 
         expect(service.isActive()).toBe(true);
-        expect(dockerService.clearContainerCache).toHaveBeenCalledTimes(1);
         expect(dockerService.getAppInfo).toHaveBeenCalledTimes(1);
         expect(pubsub.publish).toHaveBeenCalledTimes(1);
     });
@@ -190,7 +185,6 @@ describe('DockerEventService', () => {
 
         await waitForEventProcessing();
 
-        expect(dockerService.clearContainerCache).toHaveBeenCalledTimes(2);
         expect(dockerService.getAppInfo).toHaveBeenCalledTimes(2);
         expect(pubsub.publish).toHaveBeenCalledTimes(2);
     });
@@ -206,7 +200,6 @@ describe('DockerEventService', () => {
 
         await waitForEventProcessing();
 
-        expect(dockerService.clearContainerCache).toHaveBeenCalledTimes(1);
         expect(dockerService.getAppInfo).toHaveBeenCalledTimes(1);
         expect(pubsub.publish).toHaveBeenCalledTimes(1);
 
@@ -223,7 +216,6 @@ describe('DockerEventService', () => {
 
         await waitForEventProcessing();
 
-        expect(dockerService.clearContainerCache).toHaveBeenCalledTimes(1);
         expect(dockerService.getAppInfo).toHaveBeenCalledTimes(1);
         expect(pubsub.publish).toHaveBeenCalledTimes(1);
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker-event.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-event.service.ts
@@ -124,14 +124,12 @@ export class DockerEventService implements OnModuleDestroy, OnModuleInit {
         if (shouldProcess) {
             this.logger.debug(`[${dockerEvent.from}] ${dockerEvent.Type}->${actionName}`);
 
-            // For container lifecycle events, update the container cache
+            // For container lifecycle events, publish updated app info
             if (
                 dockerEvent.Type === DockerEventType.CONTAINER &&
                 typeof actionName === 'string' &&
                 this.containerActions.includes(actionName as DockerEventAction)
             ) {
-                await this.dockerService.clearContainerCache();
-                // Get updated counts and publish
                 const appInfo = await this.dockerService.getAppInfo();
                 await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
                 this.logger.debug(`Published app info update due to event: ${actionName}`);

--- a/api/src/unraid-api/graph/resolvers/docker/docker-network.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-network.service.ts
@@ -1,42 +1,20 @@
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable, Logger } from '@nestjs/common';
-
-import { type Cache } from 'cache-manager';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { catchHandlers } from '@app/core/utils/misc/catch-handlers.js';
 import { DockerNetwork } from '@app/unraid-api/graph/resolvers/docker/docker.model.js';
 import { getDockerClient } from '@app/unraid-api/graph/resolvers/docker/utils/docker-client.js';
-
-interface NetworkListingOptions {
-    skipCache: boolean;
-}
 
 @Injectable()
 export class DockerNetworkService {
     private readonly logger = new Logger(DockerNetworkService.name);
     private readonly client = getDockerClient();
 
-    public static readonly NETWORK_CACHE_KEY = 'docker_networks';
-    private static readonly CACHE_TTL_SECONDS = 60;
-
-    constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
-
     /**
      * Get all Docker networks
      * @returns All the in/active Docker networks on the system.
      */
-    public async getNetworks({ skipCache }: NetworkListingOptions): Promise<DockerNetwork[]> {
-        if (!skipCache) {
-            const cachedNetworks = await this.cacheManager.get<DockerNetwork[]>(
-                DockerNetworkService.NETWORK_CACHE_KEY
-            );
-            if (cachedNetworks) {
-                this.logger.debug('Using docker network cache');
-                return cachedNetworks;
-            }
-        }
-
-        this.logger.debug('Updating docker network cache');
+    public async getNetworks(): Promise<DockerNetwork[]> {
+        this.logger.debug('Fetching docker networks');
         const rawNetworks = await this.client.listNetworks().catch(catchHandlers.docker);
         const networks = rawNetworks.map(
             (network) =>
@@ -59,11 +37,6 @@ export class DockerNetworkService {
                 }) as DockerNetwork
         );
 
-        await this.cacheManager.set(
-            DockerNetworkService.NETWORK_CACHE_KEY,
-            networks,
-            DockerNetworkService.CACHE_TTL_SECONDS * 1000
-        );
         return networks;
     }
 }

--- a/api/src/unraid-api/graph/resolvers/docker/docker-template-scanner.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-template-scanner.service.ts
@@ -87,7 +87,7 @@ export class DockerTemplateScannerService {
         const templates = await this.loadAllTemplates(result);
 
         try {
-            const containers = await this.dockerService.getContainers({ skipCache: true });
+            const containers = await this.dockerService.getContainers();
             const config = this.dockerConfigService.getConfig();
             const currentMappings = config.templateMappings || {};
             const skipSet = new Set(config.skipTemplatePaths || []);

--- a/api/src/unraid-api/graph/resolvers/docker/docker.module.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.module.spec.ts
@@ -73,7 +73,7 @@ describe('DockerModule', () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 DockerResolver,
-                { provide: DockerService, useValue: { clearContainerCache: vi.fn() } },
+                { provide: DockerService, useValue: {} },
                 {
                     provide: DockerConfigService,
                     useValue: {

--- a/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.resolver.spec.ts
@@ -40,7 +40,6 @@ describe('DockerResolver', () => {
                         getNetworks: vi.fn(),
                         getContainerLogSizes: vi.fn(),
                         getContainerLogs: vi.fn(),
-                        clearContainerCache: vi.fn(),
                     },
                 },
                 {
@@ -161,7 +160,7 @@ describe('DockerResolver', () => {
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRootFs');
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRw');
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeLog');
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: false });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: false });
     });
 
     it('should request size when sizeRootFs field is requested', async () => {
@@ -191,7 +190,7 @@ describe('DockerResolver', () => {
         const result = await resolver.containers(false, mockInfo);
         expect(result).toEqual(mockContainers);
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRootFs');
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: true });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: true });
     });
 
     it('should request size when sizeRw field is requested', async () => {
@@ -205,7 +204,7 @@ describe('DockerResolver', () => {
 
         await resolver.containers(false, mockInfo);
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRw');
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: true });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: true });
     });
 
     it('should fetch log sizes when sizeLog field is requested', async () => {
@@ -240,7 +239,7 @@ describe('DockerResolver', () => {
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeLog');
         expect(dockerService.getContainerLogSizes).toHaveBeenCalledWith(['test-container']);
         expect(result[0]?.sizeLog).toBe(42);
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: false });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: false });
     });
 
     it('should request size when GraphQLFieldHelper indicates sizeRootFs is requested', async () => {
@@ -254,7 +253,7 @@ describe('DockerResolver', () => {
 
         await resolver.containers(false, mockInfo);
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRootFs');
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: true });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: true });
     });
 
     it('should not request size when GraphQLFieldHelper indicates sizeRootFs is not requested', async () => {
@@ -266,18 +265,19 @@ describe('DockerResolver', () => {
 
         await resolver.containers(false, mockInfo);
         expect(GraphQLFieldHelper.isFieldRequested).toHaveBeenCalledWith(mockInfo, 'sizeRootFs');
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: false, size: false });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: false });
     });
 
-    it('should handle skipCache parameter', async () => {
+    it('skipCache parameter is deprecated and ignored', async () => {
         const mockContainers: DockerContainer[] = [];
         vi.mocked(dockerService.getContainers).mockResolvedValue(mockContainers);
         vi.mocked(GraphQLFieldHelper.isFieldRequested).mockReturnValue(false);
 
         const mockInfo = {} as any;
 
+        // skipCache parameter is now deprecated and ignored
         await resolver.containers(true, mockInfo);
-        expect(dockerService.getContainers).toHaveBeenCalledWith({ skipCache: true, size: false });
+        expect(dockerService.getContainers).toHaveBeenCalledWith({ size: false });
     });
 
     it('should fetch container logs with provided arguments', async () => {

--- a/api/src/unraid-api/graph/resolvers/docker/docker.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.resolver.ts
@@ -77,7 +77,7 @@ export class DockerResolver {
     })
     @ResolveField(() => DockerContainer, { nullable: true })
     public async container(@Args('id', { type: () => PrefixedID }) id: string) {
-        const containers = await this.dockerService.getContainers({ skipCache: false });
+        const containers = await this.dockerService.getContainers();
         return containers.find((c) => c.id === id) ?? null;
     }
 
@@ -87,14 +87,18 @@ export class DockerResolver {
     })
     @ResolveField(() => [DockerContainer])
     public async containers(
-        @Args('skipCache', { defaultValue: false, type: () => Boolean }) skipCache: boolean,
+        @Args('skipCache', {
+            defaultValue: false,
+            type: () => Boolean,
+            deprecationReason: 'Caching has been removed; this parameter is now ignored',
+        })
+        _skipCache: boolean,
         @Info() info: GraphQLResolveInfo
     ) {
         const requestsRootFsSize = GraphQLFieldHelper.isFieldRequested(info, 'sizeRootFs');
         const requestsRwSize = GraphQLFieldHelper.isFieldRequested(info, 'sizeRw');
         const requestsLogSize = GraphQLFieldHelper.isFieldRequested(info, 'sizeLog');
         const containers = await this.dockerService.getContainers({
-            skipCache,
             size: requestsRootFsSize || requestsRwSize,
         });
 
@@ -114,7 +118,7 @@ export class DockerResolver {
         }
 
         const wasSynced = await this.dockerTemplateScannerService.syncMissingContainers(containers);
-        return wasSynced ? await this.dockerService.getContainers({ skipCache: true }) : containers;
+        return wasSynced ? await this.dockerService.getContainers() : containers;
     }
 
     @UsePermissions({
@@ -139,9 +143,14 @@ export class DockerResolver {
     })
     @ResolveField(() => [DockerNetwork])
     public async networks(
-        @Args('skipCache', { defaultValue: false, type: () => Boolean }) skipCache: boolean
+        @Args('skipCache', {
+            defaultValue: false,
+            type: () => Boolean,
+            deprecationReason: 'Caching has been removed; this parameter is now ignored',
+        })
+        _skipCache: boolean
     ) {
-        return this.dockerService.getNetworks({ skipCache });
+        return this.dockerService.getNetworks();
     }
 
     @UsePermissions({
@@ -150,9 +159,14 @@ export class DockerResolver {
     })
     @ResolveField(() => DockerPortConflicts)
     public async portConflicts(
-        @Args('skipCache', { defaultValue: false, type: () => Boolean }) skipCache: boolean
+        @Args('skipCache', {
+            defaultValue: false,
+            type: () => Boolean,
+            deprecationReason: 'Caching has been removed; this parameter is now ignored',
+        })
+        _skipCache: boolean
     ) {
-        return this.dockerService.getPortConflicts({ skipCache });
+        return this.dockerService.getPortConflicts();
     }
 
     @UseFeatureFlag('ENABLE_NEXT_DOCKER_RELEASE')
@@ -162,9 +176,14 @@ export class DockerResolver {
     })
     @ResolveField(() => ResolvedOrganizerV1)
     public async organizer(
-        @Args('skipCache', { defaultValue: false, type: () => Boolean }) skipCache: boolean
+        @Args('skipCache', {
+            defaultValue: false,
+            type: () => Boolean,
+            deprecationReason: 'Caching has been removed; this parameter is now ignored',
+        })
+        _skipCache: boolean
     ) {
-        return this.dockerOrganizerService.resolveOrganizer(undefined, { skipCache });
+        return this.dockerOrganizerService.resolveOrganizer();
     }
 
     @UseFeatureFlag('ENABLE_NEXT_DOCKER_RELEASE')
@@ -351,7 +370,6 @@ export class DockerResolver {
         };
         const validated = await this.dockerConfigService.validate(resetConfig);
         this.dockerConfigService.replaceConfig(validated);
-        await this.dockerService.clearContainerCache();
         return true;
     }
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.integration.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.integration.spec.ts
@@ -1,4 +1,3 @@
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mkdtemp, readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -27,12 +26,6 @@ const mockDockerConfigService = {
 const mockDockerManifestService = {
     getCachedUpdateStatuses: vi.fn().mockResolvedValue({}),
     isUpdateAvailableCached: vi.fn().mockResolvedValue(false),
-};
-
-const mockCacheManager = {
-    get: vi.fn(),
-    set: vi.fn(),
-    del: vi.fn(),
 };
 
 // Hoisted mock for paths
@@ -81,7 +74,6 @@ describe.runIf(dockerAvailable)('DockerService Integration', () => {
                 DockerLogService,
                 DockerNetworkService,
                 DockerPortService,
-                { provide: CACHE_MANAGER, useValue: mockCacheManager },
                 { provide: DockerConfigService, useValue: mockDockerConfigService },
                 { provide: DockerManifestService, useValue: mockDockerManifestService },
                 { provide: NotificationsService, useValue: mockNotificationsService },
@@ -99,7 +91,7 @@ describe.runIf(dockerAvailable)('DockerService Integration', () => {
     });
 
     it('should fetch containers from docker daemon', async () => {
-        const containers = await service.getContainers({ skipCache: true });
+        const containers = await service.getContainers();
         expect(Array.isArray(containers)).toBe(true);
         if (containers.length > 0) {
             expect(containers[0]).toHaveProperty('id');
@@ -109,7 +101,7 @@ describe.runIf(dockerAvailable)('DockerService Integration', () => {
     });
 
     it('should fetch networks from docker daemon', async () => {
-        const networks = await service.getNetworks({ skipCache: true });
+        const networks = await service.getNetworks();
         expect(Array.isArray(networks)).toBe(true);
         // Default networks (bridge, host, null) should always exist
         expect(networks.length).toBeGreaterThan(0);
@@ -118,7 +110,7 @@ describe.runIf(dockerAvailable)('DockerService Integration', () => {
     });
 
     it('should manage autostart configuration in temp files', async () => {
-        const containers = await service.getContainers({ skipCache: true });
+        const containers = await service.getContainers();
         if (containers.length === 0) {
             console.warn('No containers found, skipping autostart write test');
             return;
@@ -150,7 +142,7 @@ describe.runIf(dockerAvailable)('DockerService Integration', () => {
     });
 
     it('should get container logs using dockerode', async () => {
-        const containers = await service.getContainers({ skipCache: true });
+        const containers = await service.getContainers();
         const running = containers.find((c) => c.state === 'RUNNING'); // Enum value is string 'RUNNING'
 
         if (!running) {

--- a/api/src/unraid-api/graph/resolvers/docker/organizer/docker-organizer.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/organizer/docker-organizer.service.ts
@@ -54,14 +54,8 @@ export class DockerOrganizerService {
         private readonly dockerService: DockerService
     ) {}
 
-    async getResources(
-        opts?: Partial<ContainerListOptions> & { skipCache?: boolean }
-    ): Promise<OrganizerV1['resources']> {
-        const { skipCache = false, ...listOptions } = opts ?? {};
-        const containers = await this.dockerService.getContainers({
-            skipCache,
-            ...(listOptions as any),
-        });
+    async getResources(opts?: Partial<ContainerListOptions>): Promise<OrganizerV1['resources']> {
+        const containers = await this.dockerService.getContainers(opts);
         return containerListToResourcesObject(containers);
     }
 
@@ -83,20 +77,17 @@ export class DockerOrganizerService {
         return newOrganizer;
     }
 
-    async syncAndGetOrganizer(opts?: { skipCache?: boolean }): Promise<OrganizerV1> {
+    async syncAndGetOrganizer(): Promise<OrganizerV1> {
         let organizer = this.dockerConfigService.getConfig();
-        organizer.resources = await this.getResources(opts);
+        organizer.resources = await this.getResources();
         organizer = await this.syncDefaultView(organizer, organizer.resources);
         organizer = await this.dockerConfigService.validate(organizer);
         this.dockerConfigService.replaceConfig(organizer);
         return organizer;
     }
 
-    async resolveOrganizer(
-        organizer?: OrganizerV1,
-        opts?: { skipCache?: boolean }
-    ): Promise<ResolvedOrganizerV1> {
-        organizer ??= await this.syncAndGetOrganizer(opts);
+    async resolveOrganizer(organizer?: OrganizerV1): Promise<ResolvedOrganizerV1> {
+        organizer ??= await this.syncAndGetOrganizer();
         return resolveOrganizer(organizer);
     }
 


### PR DESCRIPTION
## Summary
- Removes 60-second TTL caching from Docker container and network queries
- Fixes stale data issues when containers are created/deleted externally (e.g., via CA)
- Ensures API queries return live, up-to-date Docker state without requiring page refreshes

## Test plan
- [x] Type checking passes (`pnpm type-check`)
- [x] All Docker-related tests pass
- [x] Verify container installs via CA appear immediately without refresh
- [x] Verify container deletions are reflected immediately without refresh

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker container and network information are now always fetched fresh from the API without caching, ensuring real-time accuracy.

* **Deprecations**
  * The skipCache parameter for Docker queries is deprecated and ignored; caching functionality has been completely removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->