### PR TITLE
fix(docker): improve logs and console UX when container is stopped

### DIFF
--- a/web/src/components/Docker/ContainerOverviewCard.vue
+++ b/web/src/components/Docker/ContainerOverviewCard.vue
@@ -40,7 +40,8 @@ const stateColor = computed(() => {
 const stateLabel = computed(() => {
   const state = props.container?.state;
   if (!state) return 'Unknown';
-  return state.charAt(0).toUpperCase() + state.slice(1);
+  if (state === 'EXITED') return 'Stopped';
+  return state.charAt(0).toUpperCase() + state.slice(1).toLowerCase();
 });
 
 const imageVersion = computed(() => formatImage(props.container));

--- a/web/src/components/Docker/DockerContainerManagement.vue
+++ b/web/src/components/Docker/DockerContainerManagement.vue
@@ -381,6 +381,15 @@ const hasActiveConsoleSession = computed(() => {
   return name ? hasActiveSession(name) : false;
 });
 
+const isContainerRunning = computed(() => activeContainer.value?.state === 'RUNNING');
+
+const consoleBadge = computed(() => {
+  if (isContainerRunning.value && hasActiveConsoleSession.value) {
+    return { color: 'success' as const, variant: 'solid' as const, class: 'w-2 h-2 p-0 min-w-0' };
+  }
+  return undefined;
+});
+
 const legacyPaneTabs = computed(() => [
   { label: 'Overview', value: 'overview' as const },
   { label: 'Settings', value: 'settings' as const },
@@ -388,9 +397,7 @@ const legacyPaneTabs = computed(() => [
   {
     label: 'Console',
     value: 'console' as const,
-    badge: hasActiveConsoleSession.value
-      ? { color: 'success' as const, variant: 'solid' as const, class: 'w-2 h-2 p-0 min-w-0' }
-      : undefined,
+    badge: consoleBadge.value,
   },
 ]);
 
@@ -550,12 +557,6 @@ const [transitionContainerRef] = useAutoAnimate({
                     {{ stripLeadingSlash(activeContainer?.names?.[0]) || 'Container' }}
                   </div>
                 </div>
-                <UBadge
-                  v-if="activeContainer?.state"
-                  :label="activeContainer.state"
-                  color="primary"
-                  variant="subtle"
-                />
               </div>
               <UTabs
                 v-model="legacyPaneTab"
@@ -606,6 +607,7 @@ const [transitionContainerRef] = useAutoAnimate({
               :container-name="stripLeadingSlash(activeContainer.names?.[0])"
               :auto-scroll="logAutoScroll"
               :client-filter="logFilterText"
+              :is-running="isContainerRunning"
               class="h-full flex-1"
             />
           </div>
@@ -617,6 +619,7 @@ const [transitionContainerRef] = useAutoAnimate({
               v-if="activeContainer"
               :container-name="activeContainerName"
               :shell="activeContainer.shell ?? 'sh'"
+              :is-running="isContainerRunning"
               class="h-full"
             />
           </div>
@@ -636,12 +639,6 @@ const [transitionContainerRef] = useAutoAnimate({
                 />
                 <div class="font-medium">Overview</div>
               </div>
-              <UBadge
-                v-if="activeContainer?.state"
-                :label="activeContainer.state"
-                color="primary"
-                variant="subtle"
-              />
             </div>
           </template>
           <div class="relative">
@@ -684,6 +681,7 @@ const [transitionContainerRef] = useAutoAnimate({
               v-if="activeContainer"
               :container-name="stripLeadingSlash(activeContainer.names?.[0])"
               :auto-scroll="true"
+              :is-running="isContainerRunning"
               class="h-full"
             />
           </div>

--- a/web/src/components/Docker/SingleDockerLogViewer.vue
+++ b/web/src/components/Docker/SingleDockerLogViewer.vue
@@ -16,9 +16,11 @@ const props = withDefaults(
     containerName: string;
     autoScroll: boolean;
     clientFilter?: string;
+    isRunning?: boolean;
   }>(),
   {
     clientFilter: '',
+    isRunning: true,
   }
 );
 
@@ -201,6 +203,8 @@ defineExpose({ refreshLogContent });
     :auto-scroll="autoScroll"
     :show-refresh="true"
     :show-download="false"
+    :dimmed="!isRunning"
+    :additional-info="!isRunning ? 'Container stopped - showing historical logs' : ''"
     @refresh="refreshLogContent"
   />
 </template>

--- a/web/src/components/Logs/BaseLogViewer.vue
+++ b/web/src/components/Logs/BaseLogViewer.vue
@@ -27,6 +27,7 @@ interface Props {
   loadingMoreContent?: boolean;
   isAtTop?: boolean;
   canLoadMore?: boolean;
+  dimmed?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -42,6 +43,7 @@ const props = withDefaults(defineProps<Props>(), {
   loadingMoreContent: false,
   isAtTop: false,
   canLoadMore: false,
+  dimmed: false,
 });
 
 const emit = defineEmits<{
@@ -168,7 +170,11 @@ defineExpose({ forceScrollToBottom, scrollViewportRef });
 
       <pre
         class="hljs m-0 p-4 font-mono text-xs leading-6 whitespace-pre"
-        :class="{ 'theme-dark': isDarkMode, 'theme-light': !isDarkMode }"
+        :class="{
+          'theme-dark': isDarkMode,
+          'theme-light': !isDarkMode,
+          'opacity-50': dimmed,
+        }"
         v-html="highlightedContent"
       />
     </div>

--- a/web/src/composables/useDockerRowActions.ts
+++ b/web/src/composables/useDockerRowActions.ts
@@ -215,7 +215,9 @@ export function useDockerRowActions(options: DockerRowActionsOptions) {
     ]);
 
     const containerName = getContainerNameFromRow(row);
-    const hasConsoleSession = containerName ? hasActiveConsoleSession(containerName) : false;
+    const isRunning = row.meta?.state === ContainerState.RUNNING;
+    const hasConsoleSession =
+      containerName && isRunning ? hasActiveConsoleSession(containerName) : false;
 
     items.push([
       {
@@ -229,6 +231,7 @@ export function useDockerRowActions(options: DockerRowActionsOptions) {
         icon: 'i-lucide-terminal',
         as: 'button',
         color: hasConsoleSession ? 'success' : undefined,
+        disabled: !isRunning,
         onSelect: () => onOpenConsole(row),
       },
       {

--- a/web/src/composables/useDockerTableColumns.ts
+++ b/web/src/composables/useDockerTableColumns.ts
@@ -54,7 +54,7 @@ export function useDockerTableColumns(options: DockerTableColumnsOptions) {
     options;
 
   const UButton = resolveComponent('UButton');
-  const UBadge = resolveComponent('UBadge');
+  const UBadge = resolveComponent('UBadge') as Component;
   const UDropdownMenu = resolveComponent('UDropdownMenu');
   const USkeleton = resolveComponent('USkeleton') as Component;
   const UIcon = resolveComponent('UIcon');
@@ -106,16 +106,22 @@ export function useDockerTableColumns(options: DockerTableColumnsOptions) {
           if (row.original.type === 'folder') return '';
           const state = row.original.state ?? '';
           const isBusy = busyRowIds.value.has(row.original.id);
-          const colorMap: Record<string, 'success' | 'warning' | 'neutral'> = {
+          const colorMap: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
             [ContainerState.RUNNING]: 'success',
             [ContainerState.PAUSED]: 'warning',
-            [ContainerState.EXITED]: 'neutral',
+            [ContainerState.EXITED]: 'error',
+          };
+          const labelMap: Record<string, string> = {
+            [ContainerState.RUNNING]: 'Running',
+            [ContainerState.PAUSED]: 'Paused',
+            [ContainerState.EXITED]: 'Stopped',
           };
           const color = colorMap[state] || 'neutral';
+          const label = labelMap[state] || state;
           if (isBusy) {
             return h(USkeleton, { class: 'h-5 w-20' });
           }
-          return h(UBadge, { color }, () => state);
+          return h(UBadge, { color, label, variant: 'subtle' });
         },
       },
       {


### PR DESCRIPTION
## Summary
- Change "Exited" status label to "Stopped" for better user clarity
- Show "Container is not running" message in console tab when container is stopped
- Dim historical logs with info message when container is stopped
- Remove redundant status badge from container detail header (status is shown in ContainerOverviewCard)
- Console tab indicator only shows green dot when container is running with active session

## Test plan
- [ ] Stop a container and verify status shows "Stopped" instead of "Exited"
- [ ] Open stopped container details and check Console tab shows "Container is not running"
- [ ] Verify Logs tab shows dimmed logs with "Container stopped - showing historical logs" message
- [ ] Verify no redundant status badge in the header area
- [ ] Start container and verify console connects properly
- [ ] Verify console indicator only shows green when running with active session

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console viewer shows a non-interactive placeholder when a container is not running and re-initializes when it starts

* **Improvements**
  * Container state labels use friendly Title Case (e.g., "Stopped" instead of "Exited")
  * Log viewer dims and annotates historical logs when a container is stopped
  * Console/tab badges and actions only enable when the container is running, improving visual consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->