### PR TITLE
feat(docker): disable containers page file modification

### DIFF
--- a/api/src/unraid-api/unraid-file-modifier/modifications/docker-containers-page.modification.ts
+++ b/api/src/unraid-api/unraid-file-modifier/modifications/docker-containers-page.modification.ts
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises';
 
-import { ENABLE_NEXT_DOCKER_RELEASE } from '@app/environment.js';
 import {
     FileModification,
     ShouldApplyWithReason,
@@ -12,28 +11,9 @@ export default class DockerContainersPageModification extends FileModification {
         '/usr/local/emhttp/plugins/dynamix.docker.manager/DockerContainers.page';
 
     async shouldApply(): Promise<ShouldApplyWithReason> {
-        const baseCheck = await super.shouldApply({ checkOsVersion: false });
-        if (!baseCheck.shouldApply) {
-            return baseCheck;
-        }
-
-        if (!ENABLE_NEXT_DOCKER_RELEASE) {
-            return {
-                shouldApply: false,
-                reason: 'ENABLE_NEXT_DOCKER_RELEASE is not enabled, so Docker overview table modification is not applied',
-            };
-        }
-
-        if (await this.isUnraidVersionGreaterThanOrEqualTo('7.3.0')) {
-            return {
-                shouldApply: true,
-                reason: 'Docker overview table WILL BE integrated in Unraid 7.3 or later. This modification is a temporary measure for testing.',
-            };
-        }
-
         return {
             shouldApply: false,
-            reason: 'Docker overview table modification is disabled for Unraid < 7.3',
+            reason: '',
         };
     }
 


### PR DESCRIPTION
## Summary
- Disables the Docker containers page file modification by always returning `shouldApply: false`
- This effectively turns off the Docker overview table modification feature

## Test plan
- [ ] Verify the API builds successfully
- [ ] Confirm the Docker containers page modification is no longer applied on Unraid servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled Docker containers page modification feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->