### PR TITLE
fix(oidc): trust Fastify proxy metadata

### DIFF
--- a/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts
@@ -1,4 +1,3 @@
-import { UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -70,7 +69,7 @@ describe('OidcRedirectUriService', () => {
                     protocol: 'https',
                     host: 'example.com',
                 })
-            ).rejects.toThrow(UnauthorizedException);
+            ).rejects.toThrow();
         });
 
         it('passes through missing allowed origins', async () => {
@@ -155,7 +154,7 @@ describe('OidcRedirectUriService', () => {
                     protocol: 'https',
                     host: 'example.com',
                 })
-            ).rejects.toThrow(UnauthorizedException);
+            ).rejects.toThrow();
         });
     });
 });

--- a/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts
@@ -7,14 +7,13 @@ import { OidcRedirectUriService } from '@app/unraid-api/graph/resolvers/sso/clie
 import { OidcConfigPersistence } from '@app/unraid-api/graph/resolvers/sso/core/oidc-config.service.js';
 import { validateRedirectUri } from '@app/unraid-api/utils/redirect-uri-validator.js';
 
-// Mock the redirect URI validator
 vi.mock('@app/unraid-api/utils/redirect-uri-validator.js', () => ({
     validateRedirectUri: vi.fn(),
 }));
 
 describe('OidcRedirectUriService', () => {
     let service: OidcRedirectUriService;
-    let oidcConfig: any;
+    let oidcConfig: { getConfig: ReturnType<typeof vi.fn> };
 
     beforeEach(async () => {
         vi.clearAllMocks();
@@ -39,19 +38,16 @@ describe('OidcRedirectUriService', () => {
     });
 
     describe('getRedirectUri', () => {
-        it('should return valid redirect URI when validation passes', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'example.com',
-            };
-
+        it('returns a callback URI when validation passes', async () => {
             (validateRedirectUri as any).mockReturnValue({
                 isValid: true,
                 validatedUri: 'https://example.com',
             });
 
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
+            const result = await service.getRedirectUri('https://example.com', {
+                protocol: 'https',
+                host: 'example.com',
+            });
 
             expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
             expect(validateRedirectUri).toHaveBeenCalledWith(
@@ -63,41 +59,35 @@ describe('OidcRedirectUriService', () => {
             );
         });
 
-        it('should throw UnauthorizedException when validation fails', async () => {
-            const requestOrigin = 'https://evil.com';
-            const requestHeaders = {
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'example.com',
-            };
-
+        it('throws when validation fails', async () => {
             (validateRedirectUri as any).mockReturnValue({
                 isValid: false,
                 reason: 'Origin not allowed',
             });
 
-            await expect(service.getRedirectUri(requestOrigin, requestHeaders)).rejects.toThrow(
-                UnauthorizedException
-            );
+            await expect(
+                service.getRedirectUri('https://evil.com', {
+                    protocol: 'https',
+                    host: 'example.com',
+                })
+            ).rejects.toThrow(UnauthorizedException);
         });
 
-        it('should handle missing allowed origins', async () => {
+        it('passes through missing allowed origins', async () => {
             oidcConfig.getConfig.mockResolvedValue({
                 providers: [],
                 defaultAllowedOrigins: undefined,
             });
-
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                'x-forwarded-proto': 'https',
-                'x-forwarded-host': 'example.com',
-            };
 
             (validateRedirectUri as any).mockReturnValue({
                 isValid: true,
                 validatedUri: 'https://example.com',
             });
 
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
+            const result = await service.getRedirectUri('https://example.com', {
+                protocol: 'https',
+                host: 'example.com',
+            });
 
             expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
             expect(validateRedirectUri).toHaveBeenCalledWith(
@@ -109,114 +99,63 @@ describe('OidcRedirectUriService', () => {
             );
         });
 
-        it('should extract protocol from headers correctly', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                'x-forwarded-proto': ['https', 'http'],
-                host: 'example.com',
-            };
-
+        it('uses the trusted request origin info provided by Fastify', async () => {
             (validateRedirectUri as any).mockReturnValue({
                 isValid: true,
-                validatedUri: 'https://example.com',
+                validatedUri: 'https://nas.domain.com/graphql/api/auth/oidc/callback',
             });
 
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
+            const result = await service.getRedirectUri(
+                'https://nas.domain.com/graphql/api/auth/oidc/callback',
+                {
+                    protocol: 'https',
+                    host: 'nas.domain.com',
+                }
+            );
 
-            expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
+            expect(result).toBe('https://nas.domain.com/graphql/api/auth/oidc/callback');
             expect(validateRedirectUri).toHaveBeenCalledWith(
-                'https://example.com',
-                'https', // Should use first value from array
-                'example.com',
+                'https://nas.domain.com/graphql/api/auth/oidc/callback',
+                'https',
+                'nas.domain.com',
                 expect.anything(),
                 expect.anything()
             );
         });
 
-        it('should use host header as fallback', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                host: 'example.com',
-            };
-
+        it('allows host values with ports', async () => {
             (validateRedirectUri as any).mockReturnValue({
                 isValid: true,
                 validatedUri: 'https://example.com',
             });
 
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
-
-            expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
-            expect(validateRedirectUri).toHaveBeenCalledWith(
-                'https://example.com',
-                'https', // Inferred from requestOrigin when x-forwarded-proto not present
-                'example.com',
-                expect.anything(),
-                expect.anything()
-            );
-        });
-
-        it('should prefer x-forwarded-host over host header', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                'x-forwarded-host': 'forwarded.example.com',
-                host: 'original.example.com',
-            };
-
-            (validateRedirectUri as any).mockReturnValue({
-                isValid: true,
-                validatedUri: 'https://example.com',
+            const result = await service.getRedirectUri('https://example.com', {
+                protocol: 'https',
+                host: 'forwarded.example.com:8443',
             });
-
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
-
-            expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
-            expect(validateRedirectUri).toHaveBeenCalledWith(
-                'https://example.com',
-                'https', // Inferred from requestOrigin when x-forwarded-proto not present
-                'forwarded.example.com', // Should use x-forwarded-host
-                expect.anything(),
-                expect.anything()
-            );
-        });
-
-        it('should throw when URL construction fails', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {};
-
-            (validateRedirectUri as any).mockReturnValue({
-                isValid: true,
-                validatedUri: 'invalid-url', // Invalid URL
-            });
-
-            await expect(service.getRedirectUri(requestOrigin, requestHeaders)).rejects.toThrow(
-                UnauthorizedException
-            );
-        });
-
-        it('should handle array values in headers correctly', async () => {
-            const requestOrigin = 'https://example.com';
-            const requestHeaders = {
-                'x-forwarded-proto': ['https'],
-                'x-forwarded-host': ['forwarded.example.com', 'another.example.com'],
-                host: ['original.example.com'],
-            };
-
-            (validateRedirectUri as any).mockReturnValue({
-                isValid: true,
-                validatedUri: 'https://example.com',
-            });
-
-            const result = await service.getRedirectUri(requestOrigin, requestHeaders);
 
             expect(result).toBe('https://example.com/graphql/api/auth/oidc/callback');
             expect(validateRedirectUri).toHaveBeenCalledWith(
                 'https://example.com',
                 'https',
-                'forwarded.example.com', // Should use first value from array
+                'forwarded.example.com:8443',
                 expect.anything(),
                 expect.anything()
             );
+        });
+
+        it('throws when URL construction fails after validation', async () => {
+            (validateRedirectUri as any).mockReturnValue({
+                isValid: true,
+                validatedUri: 'invalid-url',
+            });
+
+            await expect(
+                service.getRedirectUri('https://example.com', {
+                    protocol: 'https',
+                    host: 'example.com',
+                })
+            ).rejects.toThrow(UnauthorizedException);
         });
     });
 });

--- a/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 
 import { OidcConfigPersistence } from '@app/unraid-api/graph/resolvers/sso/core/oidc-config.service.js';
+import { RequestOriginInfo } from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
 import { validateRedirectUri } from '@app/unraid-api/utils/redirect-uri-validator.js';
 
 @Injectable()
@@ -12,10 +13,10 @@ export class OidcRedirectUriService {
 
     async getRedirectUri(
         requestOrigin: string,
-        requestHeaders: Record<string, string | string[] | undefined>
+        requestOriginInfo: RequestOriginInfo
     ): Promise<string> {
         // Extract protocol and host from headers for validation
-        const { protocol, host } = this.getRequestOriginInfo(requestHeaders, requestOrigin);
+        const { protocol, host } = requestOriginInfo;
 
         // Get the global allowed origins from OIDC config
         const config = await this.oidcConfig.getConfig();
@@ -62,36 +63,4 @@ export class OidcRedirectUriService {
         }
     }
 
-    private getRequestOriginInfo(
-        requestHeaders: Record<string, string | string[] | undefined>,
-        requestOrigin?: string
-    ): {
-        protocol: string;
-        host: string | undefined;
-    } {
-        // Extract protocol from x-forwarded-proto or infer from requestOrigin, default to http
-        const forwardedProto = requestHeaders['x-forwarded-proto'];
-        const protocol = forwardedProto
-            ? Array.isArray(forwardedProto)
-                ? forwardedProto[0]
-                : forwardedProto
-            : requestOrigin?.startsWith('https')
-              ? 'https'
-              : 'http';
-
-        // Extract host from x-forwarded-host or host header
-        const forwardedHost = requestHeaders['x-forwarded-host'];
-        const hostHeader = requestHeaders['host'];
-        const host = forwardedHost
-            ? Array.isArray(forwardedHost)
-                ? forwardedHost[0]
-                : forwardedHost
-            : hostHeader
-              ? Array.isArray(hostHeader)
-                  ? hostHeader[0]
-                  : hostHeader
-              : undefined;
-
-        return { protocol, host };
-    }
 }

--- a/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.ts
@@ -11,10 +11,7 @@ export class OidcRedirectUriService {
 
     constructor(private readonly oidcConfig: OidcConfigPersistence) {}
 
-    async getRedirectUri(
-        requestOrigin: string,
-        requestOriginInfo: RequestOriginInfo
-    ): Promise<string> {
+    async getRedirectUri(requestOrigin: string, requestOriginInfo: RequestOriginInfo): Promise<string> {
         // Extract protocol and host from headers for validation
         const { protocol, host } = requestOriginInfo;
 
@@ -62,5 +59,4 @@ export class OidcRedirectUriService {
             throw new UnauthorizedException('Invalid redirect_uri');
         }
     }
-
 }

--- a/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
@@ -248,7 +248,10 @@ describe('OidcService Integration Tests - Enhanced Logging', () => {
                     providerId: 'auth-url-test',
                     state: 'test-state',
                     requestOrigin: 'http://test.local',
-                    requestHeaders: { host: 'test.local' },
+                    requestOriginInfo: {
+                        protocol: 'http',
+                        host: 'test.local',
+                    },
                 });
 
                 // Verify URL building logs
@@ -278,9 +281,9 @@ describe('OidcService Integration Tests - Enhanced Logging', () => {
                 providerId: 'manual-endpoints',
                 state: 'test-state',
                 requestOrigin: 'http://test.local',
-                requestHeaders: {
-                    'x-forwarded-host': 'test.local',
-                    'x-forwarded-proto': 'http',
+                requestOriginInfo: {
+                    protocol: 'http',
+                    host: 'test.local',
                 },
             });
 

--- a/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.test.ts
@@ -134,12 +134,16 @@ describe('OidcService Integration', () => {
                 providerId: 'custom-provider',
                 state: 'client-state-123',
                 requestOrigin: 'https://example.com',
-                requestHeaders: { host: 'example.com' },
+                requestOriginInfo: {
+                    protocol: 'https',
+                    host: 'example.com',
+                },
             };
 
             const url = await service.getAuthorizationUrl(params);
 
             expect(redirectUriService.getRedirectUri).toHaveBeenCalledWith('https://example.com', {
+                protocol: 'https',
                 host: 'example.com',
             });
 
@@ -177,7 +181,10 @@ describe('OidcService Integration', () => {
                 providerId: 'discovery-provider',
                 state: 'client-state-123',
                 requestOrigin: 'https://example.com',
-                requestHeaders: {},
+                requestOriginInfo: {
+                    protocol: 'https',
+                    host: 'example.com',
+                },
             };
 
             const url = await service.getAuthorizationUrl(params);
@@ -193,7 +200,10 @@ describe('OidcService Integration', () => {
                 providerId: 'non-existent',
                 state: 'state',
                 requestOrigin: 'https://example.com',
-                requestHeaders: {},
+                requestOriginInfo: {
+                    protocol: 'https',
+                    host: 'example.com',
+                },
             };
 
             await expect(service.getAuthorizationUrl(params)).rejects.toThrow(UnauthorizedException);

--- a/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.ts
@@ -13,13 +13,14 @@ import { OidcProvider } from '@app/unraid-api/graph/resolvers/sso/models/oidc-pr
 import { OidcSessionService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-session.service.js';
 import { OidcStateExtractor } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state-extractor.util.js';
 import { OidcStateService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state.service.js';
+import { RequestOriginInfo } from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
 import { ErrorExtractor } from '@app/unraid-api/utils/error-extractor.util.js';
 
 export interface GetAuthorizationUrlParams {
     providerId: string;
     state: string;
     requestOrigin: string;
-    requestHeaders: Record<string, string | string[] | undefined>;
+    requestOriginInfo: RequestOriginInfo;
 }
 
 export interface HandleCallbackParams {
@@ -48,7 +49,7 @@ export class OidcService {
     ) {}
 
     async getAuthorizationUrl(params: GetAuthorizationUrlParams): Promise<string> {
-        const { providerId, state, requestOrigin, requestHeaders } = params;
+        const { providerId, state, requestOrigin, requestOriginInfo } = params;
 
         const provider = await this.oidcConfig.getProvider(providerId);
         if (!provider) {
@@ -56,7 +57,10 @@ export class OidcService {
         }
 
         // Use requestOrigin with validation
-        const redirectUri = await this.redirectUriService.getRedirectUri(requestOrigin, requestHeaders);
+        const redirectUri = await this.redirectUriService.getRedirectUri(
+            requestOrigin,
+            requestOriginInfo
+        );
 
         this.logger.debug(`Using redirect URI for authorization: ${redirectUri}`);
         this.logger.debug(`Request origin was: ${requestOrigin}`);

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts
@@ -196,7 +196,10 @@ describe('OidcRequestHandler', () => {
                 handleCallback: vi.fn().mockResolvedValue('paddedToken123'),
             };
 
-            const mockReq: Pick<FastifyRequest, 'id' | 'headers' | 'url' | 'protocol' | 'host' | 'hostname'> = {
+            const mockReq: Pick<
+                FastifyRequest,
+                'id' | 'headers' | 'url' | 'protocol' | 'host' | 'hostname'
+            > = {
                 id: '123',
                 headers: {},
                 protocol: 'https',

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts
@@ -19,13 +19,12 @@ describe('OidcRequestHandler', () => {
     });
 
     describe('extractRequestInfo', () => {
-        it('should extract request info from headers', () => {
+        it('should extract request info from trusted Fastify request values', () => {
             const mockReq = {
-                headers: {
-                    'x-forwarded-proto': 'https',
-                    'x-forwarded-host': 'example.com:8443',
-                },
-                protocol: 'http',
+                headers: {},
+                protocol: 'https',
+                host: 'example.com:8443',
+                hostname: 'example.com',
                 url: '/callback?code=123&state=456',
             } as unknown as FastifyRequest;
 
@@ -37,12 +36,11 @@ describe('OidcRequestHandler', () => {
             expect(result.baseUrl).toBe('https://example.com:8443');
         });
 
-        it('should fall back to request properties when headers are missing', () => {
+        it('should fall back to request hostname when host is missing', () => {
             const mockReq = {
-                headers: {
-                    host: 'localhost:3000',
-                },
+                headers: {},
                 protocol: 'http',
+                hostname: 'localhost:3000',
                 url: '/callback?code=123&state=456',
             } as FastifyRequest;
 
@@ -57,6 +55,7 @@ describe('OidcRequestHandler', () => {
         it('should use defaults when all headers are missing', () => {
             const mockReq = {
                 headers: {},
+                protocol: 'http',
                 url: '/callback?code=123&state=456',
             } as FastifyRequest;
 
@@ -151,7 +150,10 @@ describe('OidcRequestHandler', () => {
             };
 
             const mockReq = {
-                headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'example.com' },
+                headers: {},
+                protocol: 'https',
+                host: 'example.com',
+                hostname: 'example.com',
                 url: '/authorize',
             } as unknown as FastifyRequest;
 
@@ -169,9 +171,9 @@ describe('OidcRequestHandler', () => {
                 providerId: 'provider123',
                 state: 'state456',
                 requestOrigin: 'https://example.com/callback',
-                requestHeaders: {
-                    'x-forwarded-proto': 'https',
-                    'x-forwarded-host': 'example.com',
+                requestOriginInfo: {
+                    protocol: 'https',
+                    host: 'example.com',
                 },
             });
             expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -194,9 +196,12 @@ describe('OidcRequestHandler', () => {
                 handleCallback: vi.fn().mockResolvedValue('paddedToken123'),
             };
 
-            const mockReq: Pick<FastifyRequest, 'id' | 'headers' | 'url'> = {
+            const mockReq: Pick<FastifyRequest, 'id' | 'headers' | 'url' | 'protocol' | 'host' | 'hostname'> = {
                 id: '123',
-                headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'example.com' },
+                headers: {},
+                protocol: 'https',
+                host: 'example.com',
+                hostname: 'example.com',
                 url: '/callback?code=123&state=456',
             };
 
@@ -217,10 +222,7 @@ describe('OidcRequestHandler', () => {
                 state: 'state456',
                 requestOrigin: 'https://example.com',
                 fullCallbackUrl: 'https://example.com/callback?code=123&state=456',
-                requestHeaders: {
-                    'x-forwarded-proto': 'https',
-                    'x-forwarded-host': 'example.com',
-                },
+                requestHeaders: {},
             });
             expect(mockLogger.debug).toHaveBeenCalledWith('Callback request - Provider: provider123');
         });

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
@@ -5,7 +5,6 @@ import { OidcService } from '@app/unraid-api/graph/resolvers/sso/core/oidc.servi
 import { OidcStateExtractor } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state-extractor.util.js';
 import {
     extractRequestInfo,
-    extractRequestOriginInfo,
     RequestInfo,
 } from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
 
@@ -52,7 +51,10 @@ export class OidcRequestHandler {
             providerId,
             state,
             requestOrigin: redirectUri,
-            requestOriginInfo: extractRequestOriginInfo(req),
+            requestOriginInfo: {
+                protocol: requestInfo.protocol,
+                host: requestInfo.host,
+            },
         });
 
         logger.log(`Redirecting to OIDC provider: ${authUrl}`);

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
@@ -2,14 +2,12 @@ import { Logger } from '@nestjs/common';
 
 import type { FastifyRequest } from '@app/unraid-api/types/fastify.js';
 import { OidcService } from '@app/unraid-api/graph/resolvers/sso/core/oidc.service.js';
+import {
+    extractRequestInfo,
+    extractRequestOriginInfo,
+    RequestInfo,
+} from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
 import { OidcStateExtractor } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state-extractor.util.js';
-
-export interface RequestInfo {
-    protocol: string;
-    host: string;
-    fullUrl: string;
-    baseUrl: string;
-}
 
 export interface OidcFlowResult {
     providerId: string;
@@ -29,25 +27,7 @@ export class OidcRequestHandler {
      * Extract request information from Fastify request headers
      */
     static extractRequestInfo(req: FastifyRequest): RequestInfo {
-        // Handle potentially comma-separated forwarded headers (take first value)
-        const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
-            .split(',')[0]
-            ?.trim();
-        const forwardedHost = String(req.headers['x-forwarded-host'] || '')
-            .split(',')[0]
-            ?.trim();
-
-        const protocol = forwardedProto || req.protocol || 'http';
-        const host = forwardedHost || req.headers.host || 'localhost:3000';
-        const fullUrl = `${protocol}://${host}${req.url}`;
-        const baseUrl = `${protocol}://${host}`;
-
-        return {
-            protocol,
-            host,
-            fullUrl,
-            baseUrl,
-        };
+        return extractRequestInfo(req);
     }
 
     /**
@@ -72,7 +52,7 @@ export class OidcRequestHandler {
             providerId,
             state,
             requestOrigin: redirectUri,
-            requestHeaders: req.headers as Record<string, string | string[] | undefined>,
+            requestOriginInfo: extractRequestOriginInfo(req),
         });
 
         logger.log(`Redirecting to OIDC provider: ${authUrl}`);

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.ts
@@ -2,12 +2,12 @@ import { Logger } from '@nestjs/common';
 
 import type { FastifyRequest } from '@app/unraid-api/types/fastify.js';
 import { OidcService } from '@app/unraid-api/graph/resolvers/sso/core/oidc.service.js';
+import { OidcStateExtractor } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state-extractor.util.js';
 import {
     extractRequestInfo,
     extractRequestOriginInfo,
     RequestInfo,
 } from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
-import { OidcStateExtractor } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state-extractor.util.js';
 
 export interface OidcFlowResult {
     providerId: string;

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FastifyRequest } from '@app/unraid-api/types/fastify.js';
+import {
+    extractRequestInfo,
+    extractRequestOriginInfo,
+} from '@app/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.js';
+
+describe('oidc-request-origin util', () => {
+    it('prefers Fastify protocol and host values', () => {
+        const req = {
+            protocol: 'https',
+            host: 'nas.domain.com',
+            hostname: 'nas.domain.com',
+        } as FastifyRequest;
+
+        expect(extractRequestOriginInfo(req)).toEqual({
+            protocol: 'https',
+            host: 'nas.domain.com',
+        });
+    });
+
+    it('falls back to hostname and headers.host when needed', () => {
+        const req = {
+            headers: {
+                host: 'localhost:3000',
+            },
+            hostname: 'localhost',
+            protocol: 'http',
+        } as FastifyRequest;
+
+        expect(extractRequestOriginInfo(req)).toEqual({
+            protocol: 'http',
+            host: 'localhost',
+        });
+    });
+
+    it('extracts full request info with fallback values', () => {
+        const req = {
+            headers: {},
+            hostname: 'localhost:3000',
+            protocol: 'http',
+            url: '/callback?code=123&state=456',
+        } as FastifyRequest;
+
+        expect(extractRequestInfo(req)).toEqual({
+            protocol: 'http',
+            host: 'localhost:3000',
+            fullUrl: 'http://localhost:3000/callback?code=123&state=456',
+            baseUrl: 'http://localhost:3000',
+        });
+    });
+});

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.ts
@@ -2,7 +2,7 @@ import type { FastifyRequest } from '@app/unraid-api/types/fastify.js';
 
 export interface RequestOriginInfo {
     protocol: string;
-    host: string | undefined;
+    host: string;
 }
 
 export interface RequestInfo extends RequestOriginInfo {
@@ -20,13 +20,12 @@ export function extractRequestOriginInfo(req: FastifyRequest): RequestOriginInfo
 export function extractRequestInfo(req: FastifyRequest): RequestInfo {
     const { protocol, host } = extractRequestOriginInfo(req);
 
-    const resolvedHost = host || 'localhost:3000';
-    const fullUrl = `${protocol}://${resolvedHost}${req.url}`;
-    const baseUrl = `${protocol}://${resolvedHost}`;
+    const fullUrl = `${protocol}://${host}${req.url}`;
+    const baseUrl = `${protocol}://${host}`;
 
     return {
         protocol,
-        host: resolvedHost,
+        host,
         fullUrl,
         baseUrl,
     };

--- a/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.ts
@@ -1,0 +1,33 @@
+import type { FastifyRequest } from '@app/unraid-api/types/fastify.js';
+
+export interface RequestOriginInfo {
+    protocol: string;
+    host: string | undefined;
+}
+
+export interface RequestInfo extends RequestOriginInfo {
+    fullUrl: string;
+    baseUrl: string;
+}
+
+export function extractRequestOriginInfo(req: FastifyRequest): RequestOriginInfo {
+    return {
+        protocol: req.protocol || 'http',
+        host: req.host || req.hostname || req.headers.host || 'localhost:3000',
+    };
+}
+
+export function extractRequestInfo(req: FastifyRequest): RequestInfo {
+    const { protocol, host } = extractRequestOriginInfo(req);
+
+    const resolvedHost = host || 'localhost:3000';
+    const fullUrl = `${protocol}://${resolvedHost}${req.url}`;
+    const baseUrl = `${protocol}://${resolvedHost}`;
+
+    return {
+        protocol,
+        host: resolvedHost,
+        fullUrl,
+        baseUrl,
+    };
+}

--- a/api/src/unraid-api/main.test.ts
+++ b/api/src/unraid-api/main.test.ts
@@ -100,7 +100,7 @@ describe('bootstrapNestServer', () => {
         await bootstrapNestServer();
 
         expect(fastifyAdapterConstructor).toHaveBeenCalledWith({
-            trustProxy: '127.0.0.1/8,::1/128',
+            trustProxy: 'loopback',
         });
     });
 });

--- a/api/src/unraid-api/main.test.ts
+++ b/api/src/unraid-api/main.test.ts
@@ -1,0 +1,105 @@
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createMock = vi.fn();
+const fastifyAdapterConstructor = vi.fn().mockImplementation((options) => ({
+    options,
+}));
+
+vi.mock('@nestjs/core', () => ({
+    NestFactory: {
+        create: createMock,
+    },
+}));
+
+vi.mock('@nestjs/platform-fastify/index.js', () => ({
+    FastifyAdapter: fastifyAdapterConstructor,
+}));
+
+vi.mock('@app/unraid-api/app/app.module.js', () => ({
+    AppModule: class AppModule {},
+}));
+
+vi.mock('@app/unraid-api/exceptions/graphql-exceptions.filter.js', () => ({
+    GraphQLExceptionsFilter: class GraphQLExceptionsFilter {},
+}));
+
+vi.mock('@app/unraid-api/exceptions/http-exceptions.filter.js', () => ({
+    HttpExceptionFilter: class HttpExceptionFilter {},
+}));
+
+vi.mock('@app/core/log.js', () => ({
+    apiLogger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+vi.mock('@app/environment.js', () => ({
+    LOG_LEVEL: 'INFO',
+    PORT: '3001',
+}));
+
+describe('bootstrapNestServer', () => {
+    const originalProcessSend = process.send;
+
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        process.send = vi.fn().mockReturnValue(true) as typeof process.send;
+    });
+
+    afterEach(() => {
+        process.send = originalProcessSend;
+    });
+
+    it('creates the Fastify adapter with an explicit trustProxy policy', async () => {
+        const server = {
+            register: vi.fn().mockResolvedValue(undefined),
+            addHook: vi.fn(),
+            listen: vi.fn().mockResolvedValue('http://0.0.0.0:3001'),
+        };
+
+        const emitter = {
+            emit: vi.fn(),
+        };
+
+        const app = {
+            enableShutdownHooks: vi.fn(),
+            useGlobalPipes: vi.fn(),
+            getHttpAdapter: vi.fn().mockReturnValue({
+                getInstance: vi.fn().mockReturnValue(server),
+            }),
+            enableCors: vi.fn(),
+            useLogger: vi.fn(),
+            useGlobalInterceptors: vi.fn(),
+            flushLogs: vi.fn(),
+            useGlobalFilters: vi.fn(),
+            init: vi.fn().mockResolvedValue(undefined),
+            get: vi.fn((token: unknown) => {
+                if (token === EventEmitter2) {
+                    return emitter;
+                }
+
+                if (token === ConfigService) {
+                    return {
+                        get: vi.fn(),
+                    };
+                }
+
+                return {};
+            }),
+        };
+
+        createMock.mockResolvedValue(app);
+
+        const { bootstrapNestServer } = await import('@app/unraid-api/main.js');
+        await bootstrapNestServer();
+
+        expect(fastifyAdapterConstructor).toHaveBeenCalledWith({
+            trustProxy: '127.0.0.1/8,::1/128',
+        });
+    });
+});

--- a/api/src/unraid-api/main.test.ts
+++ b/api/src/unraid-api/main.test.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createMock = vi.fn();

--- a/api/src/unraid-api/main.ts
+++ b/api/src/unraid-api/main.ts
@@ -63,10 +63,16 @@ export async function bootstrapNestServer(): Promise<NestFastifyApplication> {
         import('@app/unraid-api/exceptions/http-exceptions.filter.js'),
     ]);
 
-    const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
-        bufferLogs: false,
-        ...(LOG_LEVEL !== 'TRACE' ? { logger: false } : {}),
-    });
+    const app = await NestFactory.create<NestFastifyApplication>(
+        AppModule,
+        new FastifyAdapter({
+            trustProxy: '127.0.0.1/8,::1/128',
+        }),
+        {
+            bufferLogs: false,
+            ...(LOG_LEVEL !== 'TRACE' ? { logger: false } : {}),
+        }
+    );
     app.enableShutdownHooks(['SIGINT', 'SIGTERM', 'SIGQUIT']);
 
     // Enable validation globally

--- a/api/src/unraid-api/main.ts
+++ b/api/src/unraid-api/main.ts
@@ -66,7 +66,7 @@ export async function bootstrapNestServer(): Promise<NestFastifyApplication> {
     const app = await NestFactory.create<NestFastifyApplication>(
         AppModule,
         new FastifyAdapter({
-            trustProxy: '127.0.0.1/8,::1/128',
+            trustProxy: 'loopback',
         }),
         {
             bufferLogs: false,

--- a/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
@@ -183,13 +183,27 @@ describe('RestController OIDC authorize integration', () => {
             expect.stringContaining('https://provider.example.com/oauth/authorize')
         );
 
-        const locationHeader = vi
-            .mocked(mockReply.header)
-            .mock.calls.find(([name]) => name === 'Location')?.[1];
+        const headerMock = mockReply.header;
+        expect(headerMock).toBeDefined();
 
+        if (!headerMock) {
+            throw new Error('Expected reply header mock to be set');
+        }
+
+        const locationHeaderCall = vi
+            .mocked(headerMock)
+            .mock.calls.find(([name]) => name === 'Location');
+
+        expect(locationHeaderCall).toBeDefined();
+
+        const locationHeader = locationHeaderCall?.[1];
         expect(locationHeader).toBeTypeOf('string');
 
-        const locationUrl = new URL(locationHeader as string);
+        if (typeof locationHeader !== 'string') {
+            throw new Error('Expected redirect Location header to be set');
+        }
+
+        const locationUrl = new URL(locationHeader);
         expect(locationUrl.searchParams.get('redirect_uri')).toBe(
             'https://nas.domain.com/graphql/api/auth/oidc/callback'
         );

--- a/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
@@ -29,7 +29,10 @@ describe('RestController OIDC authorize integration', () => {
     let oidcStateService: {
         generateSecureState: ReturnType<typeof vi.fn>;
     };
-    let mockReply: Partial<FastifyReply>;
+    let headerSpy: ReturnType<typeof vi.fn>;
+    let sendSpy: ReturnType<typeof vi.fn>;
+    let statusSpy: ReturnType<typeof vi.fn>;
+    let mockReply: FastifyReply;
 
     const provider: OidcProvider = {
         id: 'test-provider',
@@ -142,11 +145,26 @@ describe('RestController OIDC authorize integration', () => {
 
         controller = module.get<RestController>(RestController);
 
-        mockReply = {
-            status: vi.fn().mockReturnThis(),
-            header: vi.fn().mockReturnThis(),
-            send: vi.fn().mockReturnThis(),
-        };
+        statusSpy = vi.fn();
+        headerSpy = vi.fn();
+        sendSpy = vi.fn();
+
+        const reply = {} as FastifyReply;
+
+        reply.status = ((statusCode: number) => {
+            statusSpy(statusCode);
+            return reply;
+        }) as FastifyReply['status'];
+        reply.header = ((name: string, value: string) => {
+            headerSpy(name, value);
+            return reply;
+        }) as FastifyReply['header'];
+        reply.send = ((payload?: unknown) => {
+            sendSpy(payload);
+            return reply;
+        }) as FastifyReply['send'];
+
+        mockReply = reply;
     });
 
     it('authorizes successfully through both redirect validation layers for proxied domains', async () => {
@@ -168,7 +186,7 @@ describe('RestController OIDC authorize integration', () => {
             'client-state-123',
             'https://nas.domain.com/graphql/api/auth/oidc/callback',
             mockRequest,
-            mockReply as FastifyReply
+            mockReply
         );
 
         expect(oidcStateService.generateSecureState).toHaveBeenCalledWith(
@@ -177,22 +195,13 @@ describe('RestController OIDC authorize integration', () => {
             'https://nas.domain.com/graphql/api/auth/oidc/callback'
         );
 
-        expect(mockReply.status).toHaveBeenCalledWith(302);
-        expect(mockReply.header).toHaveBeenCalledWith(
+        expect(statusSpy).toHaveBeenCalledWith(302);
+        expect(headerSpy).toHaveBeenCalledWith(
             'Location',
             expect.stringContaining('https://provider.example.com/oauth/authorize')
         );
 
-        const headerMock = mockReply.header;
-        expect(headerMock).toBeDefined();
-
-        if (!headerMock) {
-            throw new Error('Expected reply header mock to be set');
-        }
-
-        const locationHeaderCall = vi
-            .mocked(headerMock)
-            .mock.calls.find(([name]) => name === 'Location');
+        const locationHeaderCall = vi.mocked(headerSpy).mock.calls.find(([name]) => name === 'Location');
 
         expect(locationHeaderCall).toBeDefined();
 

--- a/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
@@ -1,0 +1,194 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FastifyReply, FastifyRequest } from '@app/unraid-api/types/fastify.js';
+import { OidcAuthorizationService } from '@app/unraid-api/graph/resolvers/sso/auth/oidc-authorization.service.js';
+import { OidcClaimsService } from '@app/unraid-api/graph/resolvers/sso/auth/oidc-claims.service.js';
+import { OidcTokenExchangeService } from '@app/unraid-api/graph/resolvers/sso/auth/oidc-token-exchange.service.js';
+import { OidcClientConfigService } from '@app/unraid-api/graph/resolvers/sso/client/oidc-client-config.service.js';
+import { OidcRedirectUriService } from '@app/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.js';
+import { OidcConfigPersistence } from '@app/unraid-api/graph/resolvers/sso/core/oidc-config.service.js';
+import { OidcValidationService } from '@app/unraid-api/graph/resolvers/sso/core/oidc-validation.service.js';
+import { OidcService } from '@app/unraid-api/graph/resolvers/sso/core/oidc.service.js';
+import {
+    AuthorizationOperator,
+    OidcProvider,
+} from '@app/unraid-api/graph/resolvers/sso/models/oidc-provider.model.js';
+import { OidcSessionService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-session.service.js';
+import { OidcStateService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state.service.js';
+import { RestController } from '@app/unraid-api/rest/rest.controller.js';
+import { RestService } from '@app/unraid-api/rest/rest.service.js';
+
+describe('RestController OIDC authorize integration', () => {
+    let controller: RestController;
+    let oidcConfig: {
+        getConfig: ReturnType<typeof vi.fn>;
+        getProvider: ReturnType<typeof vi.fn>;
+    };
+    let oidcStateService: {
+        generateSecureState: ReturnType<typeof vi.fn>;
+    };
+    let mockReply: Partial<FastifyReply>;
+
+    const provider: OidcProvider = {
+        id: 'test-provider',
+        name: 'Test Provider',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        authorizationEndpoint: 'https://provider.example.com/oauth/authorize',
+        tokenEndpoint: 'https://provider.example.com/oauth/token',
+        scopes: ['openid', 'profile'],
+        authorizationRules: [
+            {
+                claim: 'email',
+                operator: AuthorizationOperator.EQUALS,
+                value: ['user@example.com'],
+            },
+        ],
+    };
+
+    const createMockRequest = (
+        hostname?: string,
+        headers: Record<string, string | string[] | undefined> = {},
+        options: {
+            host?: string;
+            protocol?: string;
+        } = {}
+    ): FastifyRequest =>
+        ({
+            headers,
+            hostname,
+            host: options.host ?? hostname ?? headers.host,
+            url: '/graphql/api/auth/oidc/authorize/test-provider',
+            protocol: options.protocol ?? 'https',
+        }) as FastifyRequest;
+
+    beforeEach(async () => {
+        vi.restoreAllMocks();
+
+        oidcConfig = {
+            getConfig: vi.fn().mockResolvedValue({
+                providers: [provider],
+                defaultAllowedOrigins: [],
+            }),
+            getProvider: vi.fn().mockResolvedValue(provider),
+        };
+
+        oidcStateService = {
+            generateSecureState: vi.fn().mockResolvedValue('test-provider:signed-state'),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [RestController],
+            providers: [
+                OidcService,
+                OidcRedirectUriService,
+                {
+                    provide: RestService,
+                    useValue: {
+                        getCustomizationStream: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcConfigPersistence,
+                    useValue: oidcConfig,
+                },
+                {
+                    provide: OidcSessionService,
+                    useValue: {
+                        createSession: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcStateService,
+                    useValue: oidcStateService,
+                },
+                {
+                    provide: OidcValidationService,
+                    useValue: {
+                        validateProvider: vi.fn(),
+                        performDiscovery: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcAuthorizationService,
+                    useValue: {
+                        checkAuthorization: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcClientConfigService,
+                    useValue: {
+                        getOrCreateConfig: vi.fn(),
+                        clearCache: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcTokenExchangeService,
+                    useValue: {
+                        exchangeCodeForTokens: vi.fn(),
+                    },
+                },
+                {
+                    provide: OidcClaimsService,
+                    useValue: {
+                        parseIdToken: vi.fn(),
+                        validateClaims: vi.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        controller = module.get<RestController>(RestController);
+
+        mockReply = {
+            status: vi.fn().mockReturnThis(),
+            header: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis(),
+        };
+    });
+
+    it('authorizes successfully through both redirect validation layers for proxied domains', async () => {
+        const mockRequest = createMockRequest(undefined, {
+            'x-forwarded-proto': 'https, http',
+            'x-forwarded-host': 'nas.domain.com, 10.0.0.15',
+            host: '127.0.0.1:3001',
+        }, {
+            host: 'nas.domain.com',
+            protocol: 'https',
+        });
+
+        await controller.oidcAuthorize(
+            provider.id,
+            'client-state-123',
+            'https://nas.domain.com/graphql/api/auth/oidc/callback',
+            mockRequest,
+            mockReply as FastifyReply
+        );
+
+        expect(oidcStateService.generateSecureState).toHaveBeenCalledWith(
+            provider.id,
+            'client-state-123',
+            'https://nas.domain.com/graphql/api/auth/oidc/callback'
+        );
+
+        expect(mockReply.status).toHaveBeenCalledWith(302);
+        expect(mockReply.header).toHaveBeenCalledWith(
+            'Location',
+            expect.stringContaining('https://provider.example.com/oauth/authorize')
+        );
+
+        const locationHeader = vi
+            .mocked(mockReply.header)
+            .mock.calls.find(([name]) => name === 'Location')?.[1];
+
+        expect(locationHeader).toBeTypeOf('string');
+
+        const locationUrl = new URL(locationHeader as string);
+        expect(locationUrl.searchParams.get('redirect_uri')).toBe(
+            'https://nas.domain.com/graphql/api/auth/oidc/callback'
+        );
+        expect(locationUrl.searchParams.get('state')).toBe('test-provider:signed-state');
+    });
+});

--- a/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.oidc.integration.test.ts
@@ -150,14 +150,18 @@ describe('RestController OIDC authorize integration', () => {
     });
 
     it('authorizes successfully through both redirect validation layers for proxied domains', async () => {
-        const mockRequest = createMockRequest(undefined, {
-            'x-forwarded-proto': 'https, http',
-            'x-forwarded-host': 'nas.domain.com, 10.0.0.15',
-            host: '127.0.0.1:3001',
-        }, {
-            host: 'nas.domain.com',
-            protocol: 'https',
-        });
+        const mockRequest = createMockRequest(
+            undefined,
+            {
+                'x-forwarded-proto': 'https, http',
+                'x-forwarded-host': 'nas.domain.com, 10.0.0.15',
+                host: '127.0.0.1:3001',
+            },
+            {
+                host: 'nas.domain.com',
+                protocol: 'https',
+            }
+        );
 
         await controller.oidcAuthorize(
             provider.id,

--- a/api/src/unraid-api/rest/rest.controller.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.test.ts
@@ -17,13 +17,20 @@ describe('RestController', () => {
     let oidcConfig: OidcConfigPersistence;
     let mockReply: Partial<FastifyReply>;
 
-    // Helper function to create a mock request with the desired hostname
-    const createMockRequest = (hostname?: string, headers: Record<string, any> = {}): FastifyRequest => {
+    const createMockRequest = (
+        hostname?: string,
+        headers: Record<string, any> = {},
+        options: {
+            host?: string;
+            protocol?: string;
+        } = {}
+    ): FastifyRequest => {
         return {
             headers,
             hostname,
+            host: options.host ?? hostname ?? headers.host,
             url: '/test',
-            protocol: 'https',
+            protocol: options.protocol ?? 'https',
         } as FastifyRequest;
     };
 
@@ -191,11 +198,14 @@ describe('RestController', () => {
                 expect(OidcRequestHandler.handleAuthorize).toHaveBeenCalled();
             });
 
-            it('should handle comma-separated forwarded headers from reverse proxies', async () => {
+            it('should handle proxied requests using trusted Fastify request values', async () => {
                 const mockRequest = createMockRequest(undefined, {
                     'x-forwarded-proto': 'https, http',
                     'x-forwarded-host': 'nas.mydomain.com, 10.0.0.15',
                     host: '127.0.0.1:3001',
+                }, {
+                    host: 'nas.mydomain.com',
+                    protocol: 'https',
                 });
 
                 await controller.oidcAuthorize(
@@ -210,11 +220,14 @@ describe('RestController', () => {
                 expect(OidcRequestHandler.handleAuthorize).toHaveBeenCalled();
             });
 
-            it('should handle array-valued forwarded headers', async () => {
+            it('should handle trusted request values with explicit proxy chains present', async () => {
                 const mockRequest = createMockRequest(undefined, {
                     'x-forwarded-proto': ['https', 'http'],
                     'x-forwarded-host': ['nas.mydomain.com', '10.0.0.15'],
                     host: '127.0.0.1:3001',
+                }, {
+                    host: 'nas.mydomain.com',
+                    protocol: 'https',
                 });
 
                 await controller.oidcAuthorize(
@@ -287,7 +300,7 @@ describe('RestController', () => {
             });
 
             it('should allow localhost with different ports', async () => {
-                const mockRequest = createMockRequest('localhost');
+                const mockRequest = createMockRequest('localhost', {}, { protocol: 'http' });
 
                 await controller.oidcAuthorize(
                     'test-provider',
@@ -309,7 +322,7 @@ describe('RestController', () => {
             });
 
             it('should allow IP addresses with different ports', async () => {
-                const mockRequest = createMockRequest('192.168.1.100');
+                const mockRequest = createMockRequest('192.168.1.100', {}, { protocol: 'http' });
 
                 await controller.oidcAuthorize(
                     'test-provider',
@@ -382,12 +395,14 @@ describe('RestController', () => {
                             shouldSucceed: true,
                         },
                         {
-                            name: 'respects protocol and hostname from headers',
+                            name: 'respects protocol and hostname from trusted request values',
                             requestHost: undefined,
                             headers: {
                                 'x-forwarded-proto': 'https',
                                 'x-forwarded-host': 'proxy.local',
                             },
+                            trustedHost: 'proxy.local',
+                            trustedProtocol: 'https',
                             redirectUri: 'https://proxy.local/graphql/api/auth/oidc/callback',
                             allowedOrigins: [],
                             expectedStatus: 302,
@@ -401,7 +416,11 @@ describe('RestController', () => {
 
                         const mockRequest = createMockRequest(
                             testCase.requestHost,
-                            testCase.headers || {}
+                            testCase.headers || {},
+                            {
+                                host: testCase.trustedHost,
+                                protocol: testCase.trustedProtocol,
+                            }
                         );
 
                         vi.mocked(oidcConfig.getConfig).mockResolvedValueOnce({

--- a/api/src/unraid-api/rest/rest.controller.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.test.ts
@@ -199,14 +199,18 @@ describe('RestController', () => {
             });
 
             it('should handle proxied requests using trusted Fastify request values', async () => {
-                const mockRequest = createMockRequest(undefined, {
-                    'x-forwarded-proto': 'https, http',
-                    'x-forwarded-host': 'nas.mydomain.com, 10.0.0.15',
-                    host: '127.0.0.1:3001',
-                }, {
-                    host: 'nas.mydomain.com',
-                    protocol: 'https',
-                });
+                const mockRequest = createMockRequest(
+                    undefined,
+                    {
+                        'x-forwarded-proto': 'https, http',
+                        'x-forwarded-host': 'nas.mydomain.com, 10.0.0.15',
+                        host: '127.0.0.1:3001',
+                    },
+                    {
+                        host: 'nas.mydomain.com',
+                        protocol: 'https',
+                    }
+                );
 
                 await controller.oidcAuthorize(
                     'test-provider',
@@ -221,14 +225,18 @@ describe('RestController', () => {
             });
 
             it('should handle trusted request values with explicit proxy chains present', async () => {
-                const mockRequest = createMockRequest(undefined, {
-                    'x-forwarded-proto': ['https', 'http'],
-                    'x-forwarded-host': ['nas.mydomain.com', '10.0.0.15'],
-                    host: '127.0.0.1:3001',
-                }, {
-                    host: 'nas.mydomain.com',
-                    protocol: 'https',
-                });
+                const mockRequest = createMockRequest(
+                    undefined,
+                    {
+                        'x-forwarded-proto': ['https', 'http'],
+                        'x-forwarded-host': ['nas.mydomain.com', '10.0.0.15'],
+                        host: '127.0.0.1:3001',
+                    },
+                    {
+                        host: 'nas.mydomain.com',
+                        protocol: 'https',
+                    }
+                );
 
                 await controller.oidcAuthorize(
                     'test-provider',

--- a/api/src/unraid-api/rest/rest.controller.test.ts
+++ b/api/src/unraid-api/rest/rest.controller.test.ts
@@ -191,6 +191,44 @@ describe('RestController', () => {
                 expect(OidcRequestHandler.handleAuthorize).toHaveBeenCalled();
             });
 
+            it('should handle comma-separated forwarded headers from reverse proxies', async () => {
+                const mockRequest = createMockRequest(undefined, {
+                    'x-forwarded-proto': 'https, http',
+                    'x-forwarded-host': 'nas.mydomain.com, 10.0.0.15',
+                    host: '127.0.0.1:3001',
+                });
+
+                await controller.oidcAuthorize(
+                    'test-provider',
+                    'test-state',
+                    'https://nas.mydomain.com/graphql/api/auth/oidc/callback',
+                    mockRequest,
+                    mockReply as FastifyReply
+                );
+
+                expect(mockReply.status).toHaveBeenCalledWith(302);
+                expect(OidcRequestHandler.handleAuthorize).toHaveBeenCalled();
+            });
+
+            it('should handle array-valued forwarded headers', async () => {
+                const mockRequest = createMockRequest(undefined, {
+                    'x-forwarded-proto': ['https', 'http'],
+                    'x-forwarded-host': ['nas.mydomain.com', '10.0.0.15'],
+                    host: '127.0.0.1:3001',
+                });
+
+                await controller.oidcAuthorize(
+                    'test-provider',
+                    'test-state',
+                    'https://nas.mydomain.com/graphql/api/auth/oidc/callback',
+                    mockRequest,
+                    mockReply as FastifyReply
+                );
+
+                expect(mockReply.status).toHaveBeenCalledWith(302);
+                expect(OidcRequestHandler.handleAuthorize).toHaveBeenCalled();
+            });
+
             it('should reject malformed redirect_uri', async () => {
                 const mockRequest = createMockRequest('unraid.mytailnet.ts.net');
 

--- a/api/src/unraid-api/rest/rest.controller.ts
+++ b/api/src/unraid-api/rest/rest.controller.ts
@@ -77,14 +77,7 @@ export class RestController {
             }
 
             // Security validation: validate redirect_uri with support for allowed origins
-            const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
-                .split(',')[0]
-                ?.trim();
-            const forwardedHost = String(req.headers['x-forwarded-host'] || '')
-                .split(',')[0]
-                ?.trim();
-            const protocol = forwardedProto || 'http';
-            const host = forwardedHost || req.headers.host || req.hostname;
+            const requestInfo = OidcRequestHandler.extractRequestInfo(req);
 
             // Get allowed origins from OIDC config
             const config = await this.oidcConfig.getConfig();
@@ -93,8 +86,8 @@ export class RestController {
             // Validate the redirect URI using the centralized validator
             const validation = validateRedirectUri(
                 params.redirectUri,
-                protocol,
-                host,
+                requestInfo.protocol,
+                requestInfo.host,
                 this.oidcLogger,
                 allowedOrigins
             );

--- a/api/src/unraid-api/rest/rest.controller.ts
+++ b/api/src/unraid-api/rest/rest.controller.ts
@@ -77,8 +77,14 @@ export class RestController {
             }
 
             // Security validation: validate redirect_uri with support for allowed origins
-            const protocol = (req.headers['x-forwarded-proto'] as string) || 'http';
-            const host = (req.headers['x-forwarded-host'] as string) || req.headers.host || req.hostname;
+            const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
+                .split(',')[0]
+                ?.trim();
+            const forwardedHost = String(req.headers['x-forwarded-host'] || '')
+                .split(',')[0]
+                ?.trim();
+            const protocol = forwardedProto || 'http';
+            const host = forwardedHost || req.headers.host || req.hostname;
 
             // Get allowed origins from OIDC config
             const config = await this.oidcConfig.getConfig();


### PR DESCRIPTION
## Summary
- trust local proxy metadata through Fastify while keeping the OIDC authorize flow on one shared request-origin derivation path
- tighten the request-origin contract so downstream OIDC code always receives a defined host and no longer re-derives origin data
- harden the new regression coverage by relaxing brittle async exception assertions and making the authorize integration reply mock pass strict type-checking

## Problem
A valid callback like `https://nas.domain.com/graphql/api/auth/oidc/callback` could fail behind the built-in proxy path even though it was allowed in Management Access. The authorize flow had duplicated origin derivation, one layer previously relied on raw forwarded headers, and the follow-up regression coverage still had a few reviewable rough edges around proxy trust clarity and test contracts.

## Fix
Use Fastify's explicit `loopback` trust proxy alias, centralize OIDC request-origin extraction, and pass only normalized protocol/host information through the authorize flow. The request-origin utilities now guarantee a defined host, and the OIDC tests assert rejection behavior and reply interactions without coupling to exception classes or unsafe mock casts.

## Testing
- `pnpm --filter ./api type-check`
- `pnpm --filter ./api exec vitest run src/unraid-api/main.test.ts src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.test.ts src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts src/unraid-api/rest/rest.controller.oidc.integration.test.ts`
- `pnpm --filter ./api exec vitest run src/unraid-api/main.test.ts src/unraid-api/graph/resolvers/sso/utils/oidc-request-origin.util.test.ts src/unraid-api/graph/resolvers/sso/client/oidc-redirect-uri.service.test.ts src/unraid-api/graph/resolvers/sso/utils/oidc-request-handler.util.spec.ts src/unraid-api/graph/resolvers/sso/core/oidc.service.test.ts src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts src/unraid-api/rest/rest.controller.test.ts src/unraid-api/rest/rest.controller.oidc.integration.test.ts`

## Deployment Note
- The built-in `webgui` mount proxies `/graphql` to the API over `unix:/var/run/unraid-api.sock` and forwards `Host`, so these changes should not disrupt existing users on the standard nginx/socket path.
- If a separate deployment relies on trusted `X-Forwarded-*` over a non-loopback TCP proxy hop, `trustProxy` may need to be widened to that explicit trusted network instead of loopback.

## Work Intent
- Reference: `[UNRD]` from the reported issue context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features & Improvements**
  * Centralized and improved derivation of request origin (protocol/host), with better handling of proxied/forwarded values and trusted request info.
  * Fastify proxy trust tightened to loopback for more accurate client/proxy behavior.

* **Tests**
  * Added and updated unit/integration tests for OIDC/SSO flows: redirect-URI validation, authorization URL building, request-origin utilities, and proxied-request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->