### PR TITLE
feat: Hide server name in onboarding

### DIFF
--- a/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
@@ -391,7 +391,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'Server01',
       serverDescription: 'Primary storage node',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -425,7 +425,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'Server01',
       serverDescription: '',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -459,7 +459,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'TowerFromVars',
       serverDescription: 'Primary storage node',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -494,7 +494,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'TowerFromServer',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -528,7 +528,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'TowerFromServer',
       serverDescription: 'Partner-provided comment',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -562,7 +562,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'TowerFromServer',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -594,7 +594,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: '',
+      serverName: 'TowerFromServer',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -610,7 +610,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     const payload = setCoreSettingsMock.mock.calls[0][0];
-    expect(payload.serverName).toBe('');
+    expect(payload.serverName).toBe('Tower');
     expect(payload.serverDescription).toBe('');
     expect(payload.theme).toBe('white');
     expect(payload.language).toBe('en_US');
@@ -639,45 +639,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
-      serverDescription: '',
-      timeZone: 'UTC',
-      theme: 'white',
-      language: 'en_US',
-      useSsh: false,
-    });
-    expect(onComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps invalid baseline server name hidden and out of draft settings', async () => {
-    const { wrapper, onComplete } = mountComponent();
-    await flushPromises();
-
-    const coreOnResult = coreOnResultHandlers[0];
-    coreOnResult({
-      data: {
-        server: { name: 'bad name!', comment: '' },
-        vars: { name: 'bad name!', useSsh: false, localTld: 'local' },
-        display: { theme: 'white', locale: 'en_US' },
-        systemTime: { timeZone: 'UTC' },
-      },
-    });
-    await flushPromises();
-
-    const serverNameInput = wrapper.find('input[placeholder="Tower"]');
-    const serverNameLabel = wrapper.findAll('label').find((label) => label.text() === 'Server Name');
-    const serverNameControl = serverNameLabel?.element.parentElement;
-
-    expect(serverNameControl?.classList.contains('hidden')).toBe(true);
-    expect(serverNameControl?.getAttribute('aria-hidden')).toBe('true');
-    expect(serverNameInput.attributes('tabindex')).toBe('-1');
-
-    const submitButton = wrapper.find('[data-testid="brand-button"]');
-    await submitButton.trigger('click');
-    await flushPromises();
-
-    expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
+      serverName: 'bad name!',
       serverDescription: '',
       timeZone: 'UTC',
       theme: 'white',
@@ -753,7 +715,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
+      serverName: 'Tower2',
       serverDescription: 'Primary host',
       timeZone: 'America/New_York',
       theme: 'black',
@@ -791,7 +753,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
+      serverName: 'Tower2',
       serverDescription: '',
       timeZone: 'UTC',
       theme: 'white',
@@ -829,7 +791,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
+      serverName: 'Tower2',
       serverDescription: '',
       timeZone: '',
       theme: '',
@@ -839,7 +801,7 @@ describe('OnboardingCoreSettingsStep', () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('allows initialized empty server name when baseline has a valid name', async () => {
+  it('uses baseline server name when initialized draft server name is empty', async () => {
     draftStore.coreSettingsInitialized = true;
     draftStore.serverName = '';
     draftStore.serverDescription = '';
@@ -867,7 +829,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: '',
+      serverName: 'TowerBaseline',
       serverDescription: '',
       timeZone: 'UTC',
       theme: 'white',

--- a/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
@@ -144,6 +144,21 @@ const mountComponent = (props: Record<string, unknown> = {}) => {
     global: {
       plugins: [createTestI18n()],
       stubs: {
+        UInput: {
+          props: ['modelValue', 'placeholder', 'disabled', 'maxlength', 'tabindex'],
+          emits: ['update:modelValue'],
+          template: `
+            <input
+              type="text"
+              :value="modelValue"
+              :placeholder="placeholder"
+              :disabled="disabled"
+              :maxlength="maxlength"
+              :tabindex="tabindex"
+              @input="$emit('update:modelValue', $event.target.value)"
+            />
+          `,
+        },
         USelectMenu: {
           props: ['modelValue', 'items', 'disabled'],
           emits: ['update:modelValue'],
@@ -199,12 +214,15 @@ describe('OnboardingCoreSettingsStep', () => {
     languagesError.value = null;
   });
 
-  it('marks server name controls hidden', async () => {
+  it('keeps valid server name controls hidden', async () => {
     const { wrapper } = mountComponent();
     await flushPromises();
 
     const serverNameLabel = wrapper.findAll('label').find((label) => label.text() === 'Server Name');
-    expect(serverNameLabel?.element.parentElement?.classList.contains('hidden')).toBe(true);
+    const serverNameControl = serverNameLabel?.element.parentElement;
+    expect(serverNameControl?.classList.contains('hidden')).toBe(true);
+    expect(serverNameControl?.getAttribute('aria-hidden')).toBe('true');
+    expect(wrapper.find('input[placeholder="Tower"]').attributes('tabindex')).toBe('-1');
   });
 
   it('prefers browser timezone over API on initial setup when draft timezone is empty', async () => {
@@ -373,7 +391,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'Server01',
+      serverName: '',
       serverDescription: 'Primary storage node',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -407,7 +425,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'Server01',
+      serverName: '',
       serverDescription: '',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -441,7 +459,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'TowerFromVars',
+      serverName: '',
       serverDescription: 'Primary storage node',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -476,7 +494,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'TowerFromServer',
+      serverName: '',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -510,7 +528,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'TowerFromServer',
+      serverName: '',
       serverDescription: 'Partner-provided comment',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -544,7 +562,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'TowerFromServer',
+      serverName: '',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -576,7 +594,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     expect(setCoreSettingsMock.mock.calls[0][0]).toMatchObject({
-      serverName: 'TowerFromServer',
+      serverName: '',
       serverDescription: 'Comment from API',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -592,7 +610,7 @@ describe('OnboardingCoreSettingsStep', () => {
 
     expect(setCoreSettingsMock).toHaveBeenCalledTimes(1);
     const payload = setCoreSettingsMock.mock.calls[0][0];
-    expect(payload.serverName).toBe('Tower');
+    expect(payload.serverName).toBe('');
     expect(payload.serverDescription).toBe('');
     expect(payload.theme).toBe('white');
     expect(payload.language).toBe('en_US');
@@ -601,7 +619,7 @@ describe('OnboardingCoreSettingsStep', () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('blocks submission with invalid server name', async () => {
+  it('does not block submission with invalid hidden server name', async () => {
     const { wrapper, onComplete } = mountComponent();
     await flushPromises();
 
@@ -620,8 +638,53 @@ describe('OnboardingCoreSettingsStep', () => {
     await submitButton.trigger('click');
     await flushPromises();
 
-    expect(setCoreSettingsMock).not.toHaveBeenCalled();
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(setCoreSettingsMock).toHaveBeenCalledWith({
+      serverName: '',
+      serverDescription: '',
+      timeZone: 'UTC',
+      theme: 'white',
+      language: 'en_US',
+      useSsh: false,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps invalid baseline server name hidden and out of draft settings', async () => {
+    const { wrapper, onComplete } = mountComponent();
+    await flushPromises();
+
+    const coreOnResult = coreOnResultHandlers[0];
+    coreOnResult({
+      data: {
+        server: { name: 'bad name!', comment: '' },
+        vars: { name: 'bad name!', useSsh: false, localTld: 'local' },
+        display: { theme: 'white', locale: 'en_US' },
+        systemTime: { timeZone: 'UTC' },
+      },
+    });
+    await flushPromises();
+
+    const serverNameInput = wrapper.find('input[placeholder="Tower"]');
+    const serverNameLabel = wrapper.findAll('label').find((label) => label.text() === 'Server Name');
+    const serverNameControl = serverNameLabel?.element.parentElement;
+
+    expect(serverNameControl?.classList.contains('hidden')).toBe(true);
+    expect(serverNameControl?.getAttribute('aria-hidden')).toBe('true');
+    expect(serverNameInput.attributes('tabindex')).toBe('-1');
+
+    const submitButton = wrapper.find('[data-testid="brand-button"]');
+    await submitButton.trigger('click');
+    await flushPromises();
+
+    expect(setCoreSettingsMock).toHaveBeenCalledWith({
+      serverName: '',
+      serverDescription: '',
+      timeZone: 'UTC',
+      theme: 'white',
+      language: 'en_US',
+      useSsh: false,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   it('blocks submission with too-long server description', async () => {
@@ -690,7 +753,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: 'Tower2',
+      serverName: '',
       serverDescription: 'Primary host',
       timeZone: 'America/New_York',
       theme: 'black',
@@ -728,7 +791,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: 'Tower2',
+      serverName: '',
       serverDescription: '',
       timeZone: 'UTC',
       theme: 'white',
@@ -766,7 +829,7 @@ describe('OnboardingCoreSettingsStep', () => {
     await flushPromises();
 
     expect(setCoreSettingsMock).toHaveBeenCalledWith({
-      serverName: 'Tower2',
+      serverName: '',
       serverDescription: '',
       timeZone: '',
       theme: '',
@@ -776,7 +839,7 @@ describe('OnboardingCoreSettingsStep', () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps initialized empty server name invalid even if baseline has a valid name', async () => {
+  it('allows initialized empty server name when baseline has a valid name', async () => {
     draftStore.coreSettingsInitialized = true;
     draftStore.serverName = '';
     draftStore.serverDescription = '';
@@ -803,7 +866,14 @@ describe('OnboardingCoreSettingsStep', () => {
     await submitButton.trigger('click');
     await flushPromises();
 
-    expect(setCoreSettingsMock).not.toHaveBeenCalled();
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(setCoreSettingsMock).toHaveBeenCalledWith({
+      serverName: '',
+      serverDescription: '',
+      timeZone: 'UTC',
+      theme: 'white',
+      language: 'en_US',
+      useSsh: false,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts
@@ -199,6 +199,14 @@ describe('OnboardingCoreSettingsStep', () => {
     languagesError.value = null;
   });
 
+  it('marks server name controls hidden', async () => {
+    const { wrapper } = mountComponent();
+    await flushPromises();
+
+    const serverNameLabel = wrapper.findAll('label').find((label) => label.text() === 'Server Name');
+    expect(serverNameLabel?.element.parentElement?.classList.contains('hidden')).toBe(true);
+  });
+
   it('prefers browser timezone over API on initial setup when draft timezone is empty', async () => {
     onboardingStore.completed.value = false;
 

--- a/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
@@ -479,6 +479,13 @@ describe('OnboardingSummaryStep', () => {
     refetchInstalledPluginsMock.mockResolvedValue(undefined);
   });
 
+  it('marks the server name hidden in the summary card', () => {
+    const { wrapper } = mountComponent();
+
+    const serverNameLabel = wrapper.findAll('span').find((span) => span.text() === 'Server Name');
+    expect(serverNameLabel?.element.parentElement?.classList.contains('hidden')).toBe(true);
+  });
+
   it.each([
     {
       caseName: 'skips install when plugin is already present',

--- a/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
@@ -804,22 +804,6 @@ describe('OnboardingSummaryStep', () => {
     expect(updateSshSettingsMock).not.toHaveBeenCalled();
   });
 
-  it('keeps baseline server name when draft server name is empty', async () => {
-    coreSettingsResult.value = {
-      vars: { name: 'bad name!', useSsh: false, localTld: 'local' },
-      server: { name: 'bad name!', comment: '' },
-      display: { theme: 'white', locale: 'en_US' },
-      systemTime: { timeZone: 'UTC' },
-      info: { primaryNetwork: { ipAddress: '192.168.1.2' } },
-    };
-    draftStore.serverName = '';
-
-    const { wrapper } = mountComponent();
-    await clickApply(wrapper);
-
-    expect(updateServerIdentityMock).not.toHaveBeenCalled();
-  });
-
   it.each([
     {
       caseName: 'server identity name only',
@@ -937,11 +921,11 @@ describe('OnboardingSummaryStep', () => {
     expect(updateSshSettingsMock).toHaveBeenCalledWith({ enabled: true, port: 22 });
   });
 
-  it('skips server identity when baseline query is down and draft server name is empty', async () => {
+  it('applies trusted defaults when baseline query is down and draft values are empty', async () => {
     coreSettingsResult.value = null;
     coreSettingsError.value = new Error('Graphql is offline.');
     draftStore.serverName = '';
-    draftStore.serverDescription = 'Edge host';
+    draftStore.serverDescription = '';
     draftStore.selectedTimeZone = '';
     draftStore.selectedTheme = '';
     draftStore.selectedLanguage = '';
@@ -951,7 +935,10 @@ describe('OnboardingSummaryStep', () => {
     await clickApply(wrapper);
 
     expect(updateSystemTimeMock).toHaveBeenCalledWith({ input: { timeZone: 'UTC' } });
-    expect(updateServerIdentityMock).not.toHaveBeenCalled();
+    expect(updateServerIdentityMock).toHaveBeenCalledWith({
+      name: 'Tower',
+      comment: '',
+    });
     expect(setThemeMock).toHaveBeenCalledWith({ theme: 'white' });
     expect(setLocaleMock).toHaveBeenCalledWith({ locale: 'en_US' });
     expect(updateSshSettingsMock).toHaveBeenCalledWith({ enabled: false, port: 22 });

--- a/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
@@ -804,6 +804,22 @@ describe('OnboardingSummaryStep', () => {
     expect(updateSshSettingsMock).not.toHaveBeenCalled();
   });
 
+  it('keeps baseline server name when draft server name is empty', async () => {
+    coreSettingsResult.value = {
+      vars: { name: 'bad name!', useSsh: false, localTld: 'local' },
+      server: { name: 'bad name!', comment: '' },
+      display: { theme: 'white', locale: 'en_US' },
+      systemTime: { timeZone: 'UTC' },
+      info: { primaryNetwork: { ipAddress: '192.168.1.2' } },
+    };
+    draftStore.serverName = '';
+
+    const { wrapper } = mountComponent();
+    await clickApply(wrapper);
+
+    expect(updateServerIdentityMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       caseName: 'server identity name only',
@@ -921,11 +937,11 @@ describe('OnboardingSummaryStep', () => {
     expect(updateSshSettingsMock).toHaveBeenCalledWith({ enabled: true, port: 22 });
   });
 
-  it('applies trusted defaults when baseline query is down and draft values are empty', async () => {
+  it('skips server identity when baseline query is down and draft server name is empty', async () => {
     coreSettingsResult.value = null;
     coreSettingsError.value = new Error('Graphql is offline.');
     draftStore.serverName = '';
-    draftStore.serverDescription = '';
+    draftStore.serverDescription = 'Edge host';
     draftStore.selectedTimeZone = '';
     draftStore.selectedTheme = '';
     draftStore.selectedLanguage = '';
@@ -935,10 +951,7 @@ describe('OnboardingSummaryStep', () => {
     await clickApply(wrapper);
 
     expect(updateSystemTimeMock).toHaveBeenCalledWith({ input: { timeZone: 'UTC' } });
-    expect(updateServerIdentityMock).toHaveBeenCalledWith({
-      name: 'Tower',
-      comment: '',
-    });
+    expect(updateServerIdentityMock).not.toHaveBeenCalled();
     expect(setThemeMock).toHaveBeenCalledWith({ theme: 'white' });
     expect(setLocaleMock).toHaveBeenCalledWith({ locale: 'en_US' });
     expect(updateSshSettingsMock).toHaveBeenCalledWith({ enabled: false, port: 22 });

--- a/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
@@ -356,7 +356,7 @@ const languageItems = computed(() => {
 
 const isLanguageDisabled = computed(() => isLanguagesLoading.value || !!languagesQueryError.value);
 const handleSubmit = async () => {
-  if (serverNameValidation.value || serverDescriptionValidation.value) {
+  if (serverDescriptionValidation.value) {
     error.value = t('common.error');
     return;
   }
@@ -366,7 +366,7 @@ const handleSubmit = async () => {
 
   try {
     draftStore.setCoreSettings({
-      serverName: serverName.value,
+      serverName: '',
       serverDescription: serverDescription.value,
       timeZone: selectedTimeZone.value,
       theme: selectedTheme.value,
@@ -621,7 +621,7 @@ const isBusy = computed(() => isSaving.value || (props.isSavingStep ?? false));
         <BrandButton
           :text="t('onboarding.coreSettings.next')"
           class="!bg-primary hover:!bg-primary/90 w-full min-w-[160px] !text-white shadow-md transition-all hover:shadow-lg sm:w-auto"
-          :disabled="isBusy || !!serverNameValidation || !!serverDescriptionValidation"
+          :disabled="isBusy || !!serverDescriptionValidation"
           :loading="isBusy"
           @click="handleSubmit"
           :icon-right="ChevronRightIcon"

--- a/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
@@ -355,6 +355,12 @@ const languageItems = computed(() => {
 });
 
 const isLanguageDisabled = computed(() => isLanguagesLoading.value || !!languagesQueryError.value);
+const resolveSubmittedServerName = () =>
+  serverName.value ||
+  coreSettingsResult.value?.server?.name?.trim() ||
+  coreSettingsResult.value?.vars?.name?.trim() ||
+  TRUSTED_DEFAULT_PROFILE.serverName;
+
 const handleSubmit = async () => {
   if (serverDescriptionValidation.value) {
     error.value = t('common.error');
@@ -366,7 +372,7 @@ const handleSubmit = async () => {
 
   try {
     draftStore.setCoreSettings({
-      serverName: '',
+      serverName: resolveSubmittedServerName(),
       serverDescription: serverDescription.value,
       timeZone: selectedTimeZone.value,
       theme: selectedTheme.value,

--- a/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue
@@ -441,7 +441,8 @@ const isBusy = computed(() => isSaving.value || (props.isSavingStep ?? false));
             <!-- Local Hostname Badge -->
             <div
               v-if="currentHostname"
-              class="flex items-center gap-1 rounded border border-gray-200 bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+              class="hidden items-center gap-1 rounded border border-gray-200 bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+              aria-hidden="true"
             >
               <GlobeAltIcon class="text-primary h-3 w-3" />
               {{ currentHostname }}
@@ -455,7 +456,7 @@ const isBusy = computed(() => isSaving.value || (props.isSavingStep ?? false));
       <!-- Top Grid: Server Identity & Region -->
       <div class="mb-8 grid grid-cols-1 gap-x-6 gap-y-8 md:grid-cols-2">
         <!-- Server Name -->
-        <div class="flex flex-col gap-2">
+        <div class="hidden flex-col gap-2" aria-hidden="true">
           <label class="text-highlighted text-base font-bold">
             {{ t('onboarding.coreSettings.serverName') }}
           </label>
@@ -468,6 +469,7 @@ const isBusy = computed(() => isSaving.value || (props.isSavingStep ?? false));
               size="lg"
               class="w-full"
               :class="{ '!border-red-500 focus:!border-red-500': !!serverNameValidation }"
+              tabindex="-1"
             />
             <p v-if="serverNameValidation" class="text-sm font-medium text-red-500">
               {{ serverNameValidation }}

--- a/web/src/components/Onboarding/steps/OnboardingNextStepsStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingNextStepsStep.vue
@@ -354,7 +354,8 @@ const handleCancelPowerAction = () => {
                 <div class="flex flex-col gap-0.5">
                   <span
                     v-if="activationCode?.system?.serverName"
-                    class="text-highlighted text-lg font-bold"
+                    class="text-highlighted hidden text-lg font-bold"
+                    aria-hidden="true"
                     >{{ activationCode.system.serverName }}</span
                   >
                   <span v-if="activationCode?.system?.model" class="text-muted font-medium">{{

--- a/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
@@ -406,10 +406,8 @@ interface CoreSettingsSnapshot {
   useSsh: boolean;
 }
 
-const resolveTargetCoreSettings = (
-  currentServerName = TRUSTED_DEFAULT_PROFILE.serverName
-): CoreSettingsSnapshot => ({
-  serverName: draftStore.serverName || currentServerName,
+const resolveTargetCoreSettings = (): CoreSettingsSnapshot => ({
+  serverName: draftStore.serverName || TRUSTED_DEFAULT_PROFILE.serverName,
   serverDescription: draftStore.serverDescription || TRUSTED_DEFAULT_PROFILE.serverDescription,
   timeZone: draftStore.selectedTimeZone || TRUSTED_DEFAULT_PROFILE.timeZone,
   theme: normalizeThemeName(draftStore.selectedTheme || TRUSTED_DEFAULT_PROFILE.theme),
@@ -620,8 +618,7 @@ const handleComplete = async () => {
       ? Boolean(coreSettingsResult.value?.vars?.useSsh || false)
       : TRUSTED_DEFAULT_PROFILE.useSsh;
     const currentSysModel = baselineLoaded ? coreSettingsResult.value?.vars?.sysModel || '' : '';
-    const hasDraftServerName = draftStore.serverName.trim().length > 0;
-    const targetCoreSettings = resolveTargetCoreSettings(currentName);
+    const targetCoreSettings = resolveTargetCoreSettings();
     const serverNameChanged = baselineLoaded ? targetCoreSettings.serverName !== currentName : false;
     const shouldApplyPartnerSysModel = Boolean(
       isFreshInstall.value &&
@@ -642,7 +639,7 @@ const handleComplete = async () => {
       ? targetCoreSettings.serverName !== currentName ||
         targetCoreSettings.serverDescription !== currentDescription ||
         shouldApplyPartnerSysModel
-      : hasDraftServerName;
+      : true;
     const shouldApplyTheme = baselineLoaded ? targetCoreSettings.theme !== currentTheme : true;
     const shouldApplyLocale = baselineLoaded ? targetCoreSettings.locale !== currentLocale : true;
     const shouldApplySsh = baselineLoaded ? targetCoreSettings.useSsh !== currentSsh : true;

--- a/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
@@ -1113,7 +1113,10 @@ const handleBack = () => {
             </h3>
           </div>
           <div class="space-y-3">
-            <div class="flex flex-col gap-1 text-sm sm:flex-row sm:items-start sm:justify-between">
+            <div
+              class="hidden flex-col gap-1 text-sm sm:flex-row sm:items-start sm:justify-between"
+              aria-hidden="true"
+            >
               <span class="text-muted">{{ t('onboarding.coreSettings.serverName') }}</span>
               <span class="text-highlighted font-medium break-all sm:text-right">{{ serverName }}</span>
             </div>

--- a/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
@@ -406,8 +406,10 @@ interface CoreSettingsSnapshot {
   useSsh: boolean;
 }
 
-const resolveTargetCoreSettings = (): CoreSettingsSnapshot => ({
-  serverName: draftStore.serverName || TRUSTED_DEFAULT_PROFILE.serverName,
+const resolveTargetCoreSettings = (
+  currentServerName = TRUSTED_DEFAULT_PROFILE.serverName
+): CoreSettingsSnapshot => ({
+  serverName: draftStore.serverName || currentServerName,
   serverDescription: draftStore.serverDescription || TRUSTED_DEFAULT_PROFILE.serverDescription,
   timeZone: draftStore.selectedTimeZone || TRUSTED_DEFAULT_PROFILE.timeZone,
   theme: normalizeThemeName(draftStore.selectedTheme || TRUSTED_DEFAULT_PROFILE.theme),
@@ -591,7 +593,6 @@ const handleComplete = async () => {
   try {
     const promises = [];
     const baselineLoaded = isApplyDataReady.value;
-    const targetCoreSettings = resolveTargetCoreSettings();
     let hadNonOptimisticFailures = false;
     let hadWarnings = !baselineLoaded;
     let hadSshVerificationUncertainty = false;
@@ -619,6 +620,8 @@ const handleComplete = async () => {
       ? Boolean(coreSettingsResult.value?.vars?.useSsh || false)
       : TRUSTED_DEFAULT_PROFILE.useSsh;
     const currentSysModel = baselineLoaded ? coreSettingsResult.value?.vars?.sysModel || '' : '';
+    const hasDraftServerName = draftStore.serverName.trim().length > 0;
+    const targetCoreSettings = resolveTargetCoreSettings(currentName);
     const serverNameChanged = baselineLoaded ? targetCoreSettings.serverName !== currentName : false;
     const shouldApplyPartnerSysModel = Boolean(
       isFreshInstall.value &&
@@ -639,7 +642,7 @@ const handleComplete = async () => {
       ? targetCoreSettings.serverName !== currentName ||
         targetCoreSettings.serverDescription !== currentDescription ||
         shouldApplyPartnerSysModel
-      : true;
+      : hasDraftServerName;
     const shouldApplyTheme = baselineLoaded ? targetCoreSettings.theme !== currentTheme : true;
     const shouldApplyLocale = baselineLoaded ? targetCoreSettings.locale !== currentLocale : true;
     const shouldApplySsh = baselineLoaded ? targetCoreSettings.useSsh !== currentSsh : true;


### PR DESCRIPTION
## Summary
- Keep the onboarding server-name control and related displays hidden as intended
- Ignore validation for the hidden server-name field so invalid draft/API/activation values cannot block progression
- Preserve the resolved server-name value in draft state instead of adding summary-step apply rules or forcing an empty override

## Tests
- `pnpm exec eslint src/components/Onboarding/steps/OnboardingCoreSettingsStep.vue src/components/Onboarding/steps/OnboardingSummaryStep.vue __test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts __test__/components/Onboarding/OnboardingSummaryStep.test.ts`
- `pnpm type-check`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run __test__/components/Onboarding/OnboardingCoreSettingsStep.test.ts __test__/components/Onboarding/OnboardingSummaryStep.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and updated tests to verify the Server Name control is hidden, aria-hidden, and non-focusable across onboarding screens; tests also cover submission behavior when draft or hidden server names are present.

* **Changes**
  * Server Name UI is hidden and removed from keyboard navigation across core settings, next steps, and summary.
  * Submission now proceeds using the persisted/baseline server name when the draft is empty or the server name is hidden, instead of blocking on validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
