### PR TITLE
feat(onboarding): route plugin installs through ca.unraid.net/dl proxy

### DIFF
--- a/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
+++ b/web/__test__/components/Onboarding/OnboardingSummaryStep.test.ts
@@ -528,7 +528,7 @@ describe('OnboardingSummaryStep', () => {
       },
       assertExpected: (wrapper: ReturnType<typeof mountComponent>['wrapper']) => {
         expect(installPluginMock).toHaveBeenCalledWith({
-          url: 'https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
+          url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
           name: 'Community Apps',
           forced: false,
           onEvent: expect.any(Function),

--- a/web/src/components/Onboarding/steps/OnboardingPluginsStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingPluginsStep.vue
@@ -37,19 +37,19 @@ const availablePlugins = computed(
         id: 'community-apps',
         name: t('onboarding.pluginsStep.plugins.communityApps.name'),
         description: t('onboarding.pluginsStep.plugins.communityApps.description'),
-        url: 'https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
+        url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
       },
       {
         id: 'fix-common-problems',
         name: t('onboarding.pluginsStep.plugins.fixCommonProblems.name'),
         description: t('onboarding.pluginsStep.plugins.fixCommonProblems.description'),
-        url: 'https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg',
+        url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg',
       },
       {
         id: 'tailscale',
         name: t('onboarding.pluginsStep.plugins.tailscale.name'),
         description: t('onboarding.pluginsStep.plugins.tailscale.description'),
-        url: 'https://raw.githubusercontent.com/unraid/unraid-tailscale/main/plugin/tailscale.plg',
+        url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/unraid-tailscale/main/plugin/tailscale.plg',
       },
     ] as const
 );

--- a/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
+++ b/web/src/components/Onboarding/steps/OnboardingSummaryStep.vue
@@ -429,15 +429,15 @@ type OnboardingPluginDetails = {
 
 const pluginMap: Record<string, OnboardingPluginDetails> = {
   'community-apps': {
-    url: 'https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
+    url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg',
     name: t('onboarding.pluginsStep.plugins.communityApps.name'),
   },
   'fix-common-problems': {
-    url: 'https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg',
+    url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg',
     name: t('onboarding.pluginsStep.plugins.fixCommonProblems.name'),
   },
   tailscale: {
-    url: 'https://raw.githubusercontent.com/unraid/unraid-tailscale/main/plugin/tailscale.plg',
+    url: 'https://ca.unraid.net/dl/https://raw.githubusercontent.com/unraid/unraid-tailscale/main/plugin/tailscale.plg',
     name: t('onboarding.pluginsStep.plugins.tailscale.name'),
     installedFileAliases: ['tailscale-preview.plg'],
   },


### PR DESCRIPTION
## Summary

- Prefix the three recommended plugin URLs in the onboarding flow with `https://ca.unraid.net/dl/` so installs go through the Community Applications download proxy instead of hitting `raw.githubusercontent.com` directly.
- Updates the URL list in `OnboardingPluginsStep.vue` and the parallel `pluginMap` in `OnboardingSummaryStep.vue` (the latter is what's actually passed to the `installPlugin` mutation).
- Updates the matching test expectation in `OnboardingSummaryStep.test.ts`.

## Why

Routing through `ca.unraid.net/dl/` lets the install traffic go through the same download proxy CA uses, rather than each user pulling the `.plg` straight from GitHub.

## Notes for reviewers

- The trailing `.plg` filename is preserved at the end of every URL, so the existing installed-plugin detection logic (which compares basenames against the contents of `/boot/config/plugins`) is unaffected. Tailscale's `tailscale-preview.plg` alias still works.
- The backend's `validateInstallUrl` (`api/src/unraid-api/graph/resolvers/unraid-plugins/unraid-plugins.service.ts`) only requires an http/https URL whose pathname ends in `.plg`, so the prefixed form passes validation.
- I was unable to run the web vitest suite locally — `pnpm install` fails on macOS for an unrelated native module (`@unraid/libvirt` node-gyp build). The change itself is mechanical (string-only edits with a matching test update). Would appreciate a CI run to confirm.

## Test plan

- [ ] CI passes (`pnpm test`, `pnpm lint`, `pnpm type-check`)
- [ ] Manually walk through onboarding and confirm each recommended plugin (Community Apps, Fix Common Problems, Tailscale) installs successfully via the proxied URL
- [ ] Confirm "already installed" detection still works when one of the plugins is present in `/boot/config/plugins`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved plugin installation reliability in the onboarding process by updating download paths for select plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->