### PR TITLE
fix: stale dark class theme bootstrap

### DIFF
--- a/web/__test__/store/theme.test.ts
+++ b/web/__test__/store/theme.test.ts
@@ -298,5 +298,17 @@ describe('Theme Store', () => {
       expect(document.body.classList.remove).toHaveBeenCalledWith('dark');
       expect(store.darkMode).toBe(false);
     });
+
+    it('should remove stale dark classes when only the dark mode CSS variable is light', () => {
+      document.documentElement.style.setProperty('--theme-dark-mode', '0');
+      originalDocumentElementAddClass.call(document.documentElement.classList, 'dark');
+      originalAddClassFn.call(document.body.classList, 'dark');
+
+      const store = createStore();
+
+      expect(document.documentElement.classList.remove).toHaveBeenCalledWith('dark');
+      expect(document.body.classList.remove).toHaveBeenCalledWith('dark');
+      expect(store.darkMode).toBe(false);
+    });
   });
 });

--- a/web/src/store/theme.ts
+++ b/web/src/store/theme.ts
@@ -68,12 +68,6 @@ const applyDarkClass = (isDark: boolean, darkModeRef?: { value: boolean }) => {
   }
 };
 
-const bootstrapDarkClass = (darkModeRef?: { value: boolean }) => {
-  if (isDarkModeActive()) {
-    applyDarkClass(true, darkModeRef);
-  }
-};
-
 const sanitizeTheme = (data: Partial<Theme> | null | undefined): Theme | null => {
   if (!data || typeof data !== 'object') {
     return null;
@@ -216,8 +210,7 @@ export const useThemeStore = defineStore('theme', () => {
     setTheme({ name: domThemeName });
     applyDarkClass(isDarkThemeName(domThemeName), darkMode);
   } else if (isDomAvailable()) {
-    darkMode.value = isDarkModeActive();
-    bootstrapDarkClass(darkMode);
+    applyDarkClass(isDarkModeActive(), darkMode);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Reconcile root/body `.dark` classes from the computed dark-mode state when `--theme-name` is unavailable.
- Add regression coverage for the fallback path where `--theme-dark-mode: 0` is present but stale `dark` classes remain.

## Root Cause

The previous fallback bootstrap path only added `dark` when dark mode was detected. If `--theme-name` was missing and the DOM already had stale `dark` classes, `--theme-dark-mode: 0` was not enough to actively remove them.

## Impact

Light Unraid themes can no longer keep Tailwind dark styles active just because a stale `dark` class survived on `<html>`, `<body>`, or `.unapi` containers.

## Verification

- `pnpm exec eslint src/store/theme.ts __test__/store/theme.test.ts`

Note: `pnpm exec vitest run __test__/store/theme.test.ts` is currently blocked before test collection by the existing Vue devtools / localStorage test-environment failure: `localStorage.getItem is not a function`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying dark mode CSS variable handling and cleanup of stale dark mode classes.

* **Refactor**
  * Improved dark mode initialization logic for cleaner implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/api/pull/2006)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->