### PR TITLE
fix(parity): resume continues from saved position instead of restarting

### DIFF
--- a/api/src/unraid-api/graph/resolvers/array/parity.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/array/parity.service.spec.ts
@@ -1,0 +1,141 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { readFile } from 'fs/promises';
+
+import { GraphQLError } from 'graphql';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { emcmd } from '@app/core/utils/clients/emcmd.js';
+import { ParityService } from '@app/unraid-api/graph/resolvers/array/parity.service.js';
+
+vi.mock('@app/core/utils/clients/emcmd.js', () => ({
+    emcmd: vi.fn(),
+}));
+
+vi.mock('@app/store/index.js', () => ({
+    getters: {
+        emhttp: vi.fn(),
+        paths: vi.fn(),
+    },
+}));
+
+vi.mock('fs/promises', () => ({
+    readFile: vi.fn(),
+}));
+
+describe('ParityService', () => {
+    let service: ParityService;
+    let mockEmhttp: ReturnType<typeof vi.fn>;
+    let mockEmcmd: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.resetAllMocks();
+
+        const storeMock = await import('@app/store/index.js');
+        mockEmhttp = vi.mocked(storeMock.getters.emhttp);
+        mockEmhttp.mockReturnValue({ var: { mdResync: 0 } } as never);
+        vi.mocked(storeMock.getters.paths).mockReturnValue({
+            'parity-checks': '/dev/null',
+        } as never);
+
+        // getParityHistory() is called after every updateParityCheck — stub the
+        // file read so the trailing call resolves successfully.
+        vi.mocked(readFile).mockResolvedValue(Buffer.from(''));
+
+        mockEmcmd = vi.mocked(emcmd);
+        mockEmcmd.mockResolvedValue({} as never);
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [ParityService],
+        }).compile();
+
+        service = module.get<ParityService>(ParityService);
+    });
+
+    describe('updateParityCheck', () => {
+        // Regression test for #1815. emhttpd identifies parity-check actions
+        // by the form-field NAME, not the value — so posting `cmdCheck=Resume`
+        // falls through to the plain `cmdCheck` submit handler (start a
+        // fresh check), discarding mdResyncPos and restarting from byte 0.
+        // The web UI submits `cmdCheckResume=`, and so must we.
+        it('resume sends `cmdCheckResume` (matches the Unraid web UI)', async () => {
+            mockEmhttp.mockReturnValue({ var: { mdResync: 17578328012 } } as never);
+
+            await service.updateParityCheck({ wantedState: 'resume', correct: false });
+
+            expect(mockEmcmd).toHaveBeenCalledWith({
+                startState: 'STARTED',
+                cmdCheckResume: '',
+            });
+        });
+
+        it('pause sends `cmdCheckPause`', async () => {
+            mockEmhttp.mockReturnValue({ var: { mdResync: 17578328012 } } as never);
+
+            await service.updateParityCheck({ wantedState: 'pause', correct: false });
+
+            expect(mockEmcmd).toHaveBeenCalledWith({
+                startState: 'STARTED',
+                cmdCheckPause: '',
+            });
+        });
+
+        it('cancel sends `cmdCheckCancel`', async () => {
+            mockEmhttp.mockReturnValue({ var: { mdResync: 17578328012 } } as never);
+
+            await service.updateParityCheck({ wantedState: 'cancel', correct: false });
+
+            expect(mockEmcmd).toHaveBeenCalledWith({
+                startState: 'STARTED',
+                cmdCheckCancel: '',
+            });
+        });
+
+        it('start sends `cmdCheck: "Check"`', async () => {
+            await service.updateParityCheck({ wantedState: 'start', correct: false });
+
+            expect(mockEmcmd).toHaveBeenCalledWith({
+                startState: 'STARTED',
+                cmdCheck: 'Check',
+            });
+        });
+
+        it('start with correct: true also writes corrections', async () => {
+            await service.updateParityCheck({ wantedState: 'start', correct: true });
+
+            expect(mockEmcmd).toHaveBeenCalledWith({
+                startState: 'STARTED',
+                cmdCheck: 'Check',
+                optionCorrect: 'correct',
+            });
+        });
+
+        it('rejects `start` when a parity check is already running', async () => {
+            mockEmhttp.mockReturnValue({ var: { mdResync: 17578328012 } } as never);
+
+            await expect(
+                service.updateParityCheck({ wantedState: 'start', correct: false })
+            ).rejects.toThrow(GraphQLError);
+            expect(mockEmcmd).not.toHaveBeenCalled();
+        });
+
+        it('rejects an unknown wantedState', async () => {
+            await expect(
+                service.updateParityCheck({
+                    // @ts-expect-error: deliberately invalid state to verify guard
+                    wantedState: 'bogus',
+                    correct: false,
+                })
+            ).rejects.toThrow(GraphQLError);
+            expect(mockEmcmd).not.toHaveBeenCalled();
+        });
+
+        it('wraps emcmd failures as GraphQLError', async () => {
+            mockEmcmd.mockRejectedValue(new Error('emhttpd unavailable'));
+
+            await expect(
+                service.updateParityCheck({ wantedState: 'start', correct: false })
+            ).rejects.toThrowError(/emhttpd unavailable/);
+        });
+    });
+});

--- a/api/src/unraid-api/graph/resolvers/array/parity.service.ts
+++ b/api/src/unraid-api/graph/resolvers/array/parity.service.ts
@@ -63,15 +63,21 @@ export class ParityService {
     }): Promise<ParityCheck[]> {
         const { getters } = await import('@app/store/index.js');
         const running = getters.emhttp().var.mdResync !== 0;
+        // Match the field names the Unraid web UI submits — emhttpd
+        // identifies the action by the field NAME, not its value. Sending
+        // `cmdCheck=Resume` would fall through to the plain `cmdCheck`
+        // submit handler (start a fresh check), discarding the saved
+        // mdResyncPos so the resumed parity restarts from byte 0.
+        // See /usr/local/emhttp/plugins/dynamix/ArrayOperation.page.
         const states = {
             pause: {
-                cmdNoCheck: 'Pause',
+                cmdCheckPause: '',
             },
             resume: {
-                cmdCheck: 'Resume',
+                cmdCheckResume: '',
             },
             cancel: {
-                cmdNoCheck: 'Cancel',
+                cmdCheckCancel: '',
             },
             start: {
                 cmdCheck: 'Check',


### PR DESCRIPTION
Fixes #1815.

## Root cause

`emhttpd` identifies parity-check actions by the **form field NAME**, not the value. The current resolver posts `cmdCheck=Resume`, which falls through to the plain `cmdCheck` submit handler (start a fresh check) and discards `mdResyncPos`, so a resumed parity restarts from byte 0.

The Unraid web UI submits **dynamic field names** with empty values (see `/usr/local/emhttp/plugins/dynamix/ArrayOperation.page:330-338`):

```html
<input type="hidden" name="cmdCheckResume" value="">
```

## Fix

Realign `ParityService.updateParityCheck` to match the web UI's field names:

```ts
const states = {
    pause:  { cmdCheckPause:  '' },
    resume: { cmdCheckResume: '' },
    cancel: { cmdCheckCancel: '' },
    start:  { cmdCheck: 'Check' },   // unchanged
};
```

`pause` and `cancel` previously used `cmdNoCheck=Pause`/`cmdNoCheck=Cancel`, which seem to have worked via fallback handling in emhttpd — they're realigned here too so the API contract matches the web UI exactly.

## Tests

Adds `parity.service.spec.ts` covering each state and a regression test that fails if `cmdCheck=Resume` is reintroduced. 8 tests pass.

## Manual verification

Tested live on Unraid 7.3.0 by patching the running bundle and exercising start → pause → resume via GraphQL:

| Stage | `mdResyncPos` |
|---|---|
| Before pause | 521 044 |
| After pause  | 1 655 644 (saved) |
| After resume | 2 395 484 (continued growing, not reset to 0) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parity check pause, resume, and cancel operations to align with system expectations
  * Resume operations now correctly preserve progress position

* **Tests**
  * Added comprehensive unit test suite for parity check control functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/api/pull/2009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->