### PR TITLE
[codex] Embed internal OS update checks on Tools page

### DIFF
--- a/web/__test__/components/UpdateOs.test.ts
+++ b/web/__test__/components/UpdateOs.test.ts
@@ -13,16 +13,6 @@ import { createTestI18n } from '../utils/i18n';
 
 vi.mock('@unraid/ui', () => ({
   PageContainer: { template: '<div><slot /></div>' },
-  BrandButton: {
-    template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
-  },
-}));
-
-const mockAccountStore = {
-  updateOs: vi.fn(),
-};
-vi.mock('~/store/account', () => ({
-  useAccountStore: () => mockAccountStore,
 }));
 
 const mockRebootType = ref('');
@@ -35,6 +25,17 @@ vi.mock('~/store/server', () => ({
   useServerStore: () => mockServerStore,
 }));
 
+const mockUpdateOsStore = {
+  available: undefined as string | undefined,
+  availableWithRenewal: undefined as string | undefined,
+  localCheckForUpdate: vi.fn().mockResolvedValue(undefined),
+  setModalOpen: vi.fn(),
+  updateOsModalVisible: false,
+};
+vi.mock('~/store/updateOs', () => ({
+  useUpdateOsStore: () => mockUpdateOsStore,
+}));
+
 // Mock window.location
 Object.defineProperty(window, 'location', {
   value: {
@@ -44,10 +45,6 @@ Object.defineProperty(window, 'location', {
   configurable: true,
 });
 
-vi.mock('~/helpers/urls', () => ({
-  WEBGUI_TOOLS_UPDATE: '/Tools/Update',
-}));
-
 const UpdateOsStatusStub = {
   template: '<div data-testid="update-os-status">Status</div>',
   props: ['showUpdateCheck', 'title', 'subtitle', 't'],
@@ -56,13 +53,23 @@ const UpdateOsThirdPartyDriversStub = {
   template: '<div data-testid="third-party-drivers">Third Party</div>',
   props: ['t'],
 };
+const UpdateOsCheckUpdateResponseModalStub = {
+  template: '<div v-if="open" data-testid="update-os-check-response">Check Response</div>',
+  props: ['open', 'embedded'],
+};
+const UpdateOsChangelogModalStub = {
+  template: '<div data-testid="update-os-changelog">Changelog</div>',
+};
 
 describe('UpdateOs.standalone.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRebootType.value = '';
     mockSetRebootVersion.mockClear();
-    mockAccountStore.updateOs.mockClear();
+    mockUpdateOsStore.available = undefined;
+    mockUpdateOsStore.availableWithRenewal = undefined;
+    mockUpdateOsStore.localCheckForUpdate.mockResolvedValue(undefined);
+    mockUpdateOsStore.updateOsModalVisible = false;
     window.location.pathname = '/some/other/path';
   });
 
@@ -99,7 +106,7 @@ describe('UpdateOs.standalone.vue', () => {
   });
 
   describe('Initial Rendering and onBeforeMount Logic', () => {
-    it('shows account button and does not auto-redirect when path matches and rebootType is empty', async () => {
+    it('shows the internal update status when path matches and rebootType is empty', async () => {
       window.location.pathname = '/Tools/Update';
       mockRebootType.value = '';
 
@@ -107,21 +114,22 @@ describe('UpdateOs.standalone.vue', () => {
         global: {
           plugins: [createTestingPinia({ createSpy: vi.fn }), createTestI18n()],
           stubs: {
-            // Rely on @unraid/ui mock for PageContainer & BrandButton
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
 
       await nextTick();
 
-      expect(mockAccountStore.updateOs).not.toHaveBeenCalled();
-      expect(wrapper.find('[data-testid="update-os-account-button"]').exists()).toBe(true);
-      expect(wrapper.find('[data-testid="update-os-status"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="update-os-status"]').exists()).toBe(true);
+      expect(wrapper.findComponent(UpdateOsStatusStub).props('showUpdateCheck')).toBe(true);
+      expect(mockUpdateOsStore.localCheckForUpdate).toHaveBeenCalledTimes(1);
     });
 
-    it('shows status and does not call updateOs when path does not match', async () => {
+    it('shows status when path does not match', async () => {
       window.location.pathname = '/some/other/path';
       mockRebootType.value = '';
 
@@ -129,21 +137,22 @@ describe('UpdateOs.standalone.vue', () => {
         global: {
           plugins: [createTestingPinia({ createSpy: vi.fn }), createTestI18n()],
           stubs: {
-            // Rely on @unraid/ui mock for PageContainer & BrandLoading
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
 
       await nextTick();
 
-      expect(mockAccountStore.updateOs).not.toHaveBeenCalled();
-      expect(wrapper.find('[data-testid="update-os-account-button"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="update-os-status"]').exists()).toBe(true);
+      expect(mockUpdateOsStore.localCheckForUpdate).not.toHaveBeenCalled();
+      expect(mockUpdateOsStore.setModalOpen).not.toHaveBeenCalled();
     });
 
-    it('shows status and does not call updateOs when rebootType is not empty', async () => {
+    it('shows status when rebootType is not empty', async () => {
       window.location.pathname = '/Tools/Update';
       mockRebootType.value = 'downgrade';
 
@@ -151,23 +160,48 @@ describe('UpdateOs.standalone.vue', () => {
         global: {
           plugins: [createTestingPinia({ createSpy: vi.fn }), createTestI18n()],
           stubs: {
-            // Rely on @unraid/ui mock for PageContainer & BrandLoading
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
 
       await nextTick();
 
-      expect(mockAccountStore.updateOs).not.toHaveBeenCalled();
-      expect(wrapper.find('[data-testid="update-os-account-button"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="update-os-status"]').exists()).toBe(true);
+      expect(mockUpdateOsStore.localCheckForUpdate).not.toHaveBeenCalled();
+      expect(mockUpdateOsStore.setModalOpen).not.toHaveBeenCalled();
     });
 
-    it('navigates to account update when the button is clicked', async () => {
+    it('opens the update modal when an update is already available', async () => {
       window.location.pathname = '/Tools/Update';
       mockRebootType.value = '';
+      mockUpdateOsStore.available = '6.12.5';
+
+      mount(UpdateOs, {
+        global: {
+          plugins: [createTestingPinia({ createSpy: vi.fn }), createTestI18n()],
+          stubs: {
+            UpdateOsStatus: UpdateOsStatusStub,
+            UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(mockUpdateOsStore.setModalOpen).toHaveBeenCalledWith(true);
+      expect(mockUpdateOsStore.localCheckForUpdate).not.toHaveBeenCalled();
+    });
+
+    it('embeds the update response on the Tools update page', async () => {
+      window.location.pathname = '/Tools/Update';
+      mockRebootType.value = '';
+      mockUpdateOsStore.updateOsModalVisible = true;
 
       const wrapper = mount(UpdateOs, {
         global: {
@@ -175,15 +209,19 @@ describe('UpdateOs.standalone.vue', () => {
           stubs: {
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
 
       await nextTick();
 
-      await wrapper.find('[data-testid="update-os-account-button"]').trigger('click');
-
-      expect(mockAccountStore.updateOs).toHaveBeenCalledWith(true);
+      const checkResponse = wrapper.findComponent(UpdateOsCheckUpdateResponseModalStub);
+      expect(checkResponse.exists()).toBe(true);
+      expect(checkResponse.props('embedded')).not.toBe(false);
+      expect(wrapper.find('[data-testid="update-os-check-response"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="update-os-changelog"]').exists()).toBe(true);
     });
   });
 
@@ -196,6 +234,8 @@ describe('UpdateOs.standalone.vue', () => {
           stubs: {
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
@@ -216,6 +256,8 @@ describe('UpdateOs.standalone.vue', () => {
           stubs: {
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });
@@ -233,6 +275,8 @@ describe('UpdateOs.standalone.vue', () => {
           stubs: {
             UpdateOsStatus: UpdateOsStatusStub,
             UpdateOsThirdPartyDrivers: UpdateOsThirdPartyDriversStub,
+            UpdateOsCheckUpdateResponseModal: UpdateOsCheckUpdateResponseModalStub,
+            UpdateOsChangelogModal: UpdateOsChangelogModalStub,
           },
         },
       });

--- a/web/src/components/UpdateOs.standalone.vue
+++ b/web/src/components/UpdateOs.standalone.vue
@@ -15,18 +15,19 @@ else
   echo "Third party plugins found - PLEASE CHECK YOUR UNRAID NOTIFICATIONS AND WAIT FOR THE MESSAGE THAT IT IS SAFE TO REBOOT!"
 fi
  */
-import { computed, onBeforeMount } from 'vue';
+import { computed, onBeforeMount, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 
-import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/solid';
-import { BrandButton, PageContainer } from '@unraid/ui';
+import { PageContainer } from '@unraid/ui';
 import { WEBGUI_TOOLS_UPDATE } from '~/helpers/urls';
 
+import UpdateOsChangelogModal from '~/components/UpdateOs/ChangelogModal.vue';
+import UpdateOsCheckUpdateResponseModal from '~/components/UpdateOs/CheckUpdateResponseModal.vue';
 import UpdateOsStatus from '~/components/UpdateOs/Status.vue';
 import UpdateOsThirdPartyDrivers from '~/components/UpdateOs/ThirdPartyDrivers.vue';
-import { useAccountStore } from '~/store/account';
 import { useServerStore } from '~/store/server';
+import { useUpdateOsStore } from '~/store/updateOs';
 
 const { t } = useI18n();
 
@@ -37,9 +38,14 @@ const props = withDefaults(defineProps<Props>(), {
   rebootVersion: '',
 });
 
-const accountStore = useAccountStore();
 const serverStore = useServerStore();
+const updateOsStore = useUpdateOsStore();
 const { rebootType } = storeToRefs(serverStore);
+const updateOsModalVisible = computed(() => updateOsStore.updateOsModalVisible);
+
+const isToolsUpdatePage = computed(
+  () => typeof window !== 'undefined' && window.location.pathname === WEBGUI_TOOLS_UPDATE
+);
 
 const subtitle = computed(() => {
   if (rebootType.value === 'downgrade') {
@@ -48,48 +54,43 @@ const subtitle = computed(() => {
   return '';
 });
 
-// Show a prompt to continue in the Account app when no reboot is pending.
-const showRedirectPrompt = computed(
-  () =>
-    typeof window !== 'undefined' &&
-    window.location.pathname === WEBGUI_TOOLS_UPDATE &&
-    rebootType.value === ''
-);
-
-const openAccountUpdate = () => {
-  accountStore.updateOs(true);
-};
-
 onBeforeMount(() => {
   serverStore.setRebootVersion(props.rebootVersion);
+});
+
+onMounted(() => {
+  if (
+    typeof window === 'undefined' ||
+    window.location.pathname !== WEBGUI_TOOLS_UPDATE ||
+    rebootType.value !== ''
+  ) {
+    return;
+  }
+
+  if (updateOsStore.available || updateOsStore.availableWithRenewal) {
+    updateOsStore.setModalOpen(true);
+    return;
+  }
+
+  void updateOsStore.localCheckForUpdate().catch((error: unknown) => {
+    console.error(error);
+  });
 });
 </script>
 
 <template>
   <PageContainer>
-    <div
-      v-if="showRedirectPrompt"
-      class="mx-auto flex max-w-[720px] flex-col items-center gap-4 py-8 text-center"
-    >
-      <h1 class="text-2xl font-semibold">{{ t('updateOs.updateUnraidOs') }}</h1>
-      <p class="text-base leading-relaxed opacity-75">
-        {{ t('updateOs.update.receiveTheLatestAndGreatestFor') }}
-      </p>
-      <BrandButton
-        data-testid="update-os-account-button"
-        :icon-right="ArrowTopRightOnSquareIcon"
-        @click="openAccountUpdate"
-      >
-        {{ t('updateOs.update.viewAvailableUpdates') }}
-      </BrandButton>
-    </div>
-    <div v-else>
-      <UpdateOsStatus
-        :show-update-check="true"
-        :title="t('updateOs.updateUnraidOs')"
-        :subtitle="subtitle"
-      />
-      <UpdateOsThirdPartyDrivers v-if="rebootType === 'thirdPartyDriversDownloading'" />
-    </div>
+    <UpdateOsStatus
+      :show-update-check="true"
+      :title="t('updateOs.updateUnraidOs')"
+      :subtitle="subtitle"
+    />
+    <UpdateOsCheckUpdateResponseModal
+      v-if="isToolsUpdatePage && rebootType === ''"
+      :open="updateOsModalVisible"
+      embedded
+    />
+    <UpdateOsChangelogModal v-if="isToolsUpdatePage" />
+    <UpdateOsThirdPartyDrivers v-if="rebootType === 'thirdPartyDriversDownloading'" />
   </PageContainer>
 </template>

--- a/web/src/components/UpdateOs/CheckUpdateResponseModal.vue
+++ b/web/src/components/UpdateOs/CheckUpdateResponseModal.vue
@@ -16,6 +16,7 @@ import {
   BrandButton,
   BrandLoading,
   Button,
+  CardWrapper,
   cn,
   DialogDescription,
   Label,
@@ -40,10 +41,12 @@ import { useServerStore } from '~/store/server';
 import { useUpdateOsStore } from '~/store/updateOs';
 
 export interface Props {
+  embedded?: boolean;
   open?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
+  embedded: false,
   open: false,
 });
 const { t } = useI18n();
@@ -281,7 +284,153 @@ const modalWidth = computed(() => {
 </script>
 
 <template>
+  <CardWrapper v-if="embedded && open" :increased-padding="true">
+    <div class="flex h-full flex-col gap-6">
+      <div v-if="modalCopy?.title" class="grid gap-y-2">
+        <h2 class="text-xl font-semibold">
+          {{ modalCopy.title }}
+        </h2>
+        <p v-if="modalCopy?.description" class="text-muted-foreground text-sm">
+          <span v-html="modalCopy.description" />
+        </p>
+      </div>
+
+      <div v-if="renderMainSlot" class="flex flex-1 flex-col gap-6 overflow-y-auto">
+        <BrandLoading v-if="checkForUpdatesLoading" class="mx-auto w-[150px]" />
+        <div v-else class="flex flex-col gap-y-6">
+          <div v-if="available || availableWithRenewal" class="flex flex-col items-center gap-4 py-4">
+            <div class="bg-primary/10 flex items-center justify-center rounded-full p-4">
+              <ArrowDownTrayIcon class="text-primary h-8 w-8" />
+            </div>
+            <div class="text-center">
+              <h2 class="text-foreground text-3xl font-bold">
+                {{ availableWithRenewal || available }}
+              </h2>
+              <p v-if="userFormattedReleaseDate" class="text-muted-foreground mt-2 text-center text-sm">
+                Released on {{ userFormattedReleaseDate }}
+              </p>
+              <p
+                v-if="availableRequiresAuth && !availableWithRenewal"
+                class="mt-2 text-center text-sm text-amber-500"
+              >
+                {{ t('updateOs.checkUpdateResponseModal.requiresVerificationToUpdate') }}
+              </p>
+            </div>
+            <div class="mt-4">
+              <div
+                class="hover:bg-muted/50 flex cursor-pointer items-center gap-3 rounded-lg p-2 transition-colors"
+                @click="ignoreThisRelease = !ignoreThisRelease"
+              >
+                <Switch v-model="ignoreThisRelease" @click.stop />
+                <Label class="text-muted-foreground cursor-pointer text-sm">
+                  {{ t('updateOs.checkUpdateResponseModal.ignoreThisReleaseUntilNextReboot') }}
+                </Label>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="showNoUpdateContent" class="flex flex-col items-center gap-4 py-6 text-center">
+            <div class="bg-primary/10 flex items-center justify-center rounded-full p-4">
+              <CheckCircleIcon class="text-primary h-10 w-10" />
+            </div>
+            <div class="space-y-2">
+              <p v-if="osVersion" class="text-muted-foreground text-center text-sm font-semibold">
+                {{ t('updateOs.checkUpdateResponseModal.currentVersion', [osVersion]) }}
+              </p>
+              <p
+                v-if="modalCopy?.description"
+                class="text-muted-foreground text-xs sm:text-sm"
+                v-html="modalCopy.description"
+              />
+            </div>
+          </div>
+
+          <div
+            v-if="extraLinks.length > 0"
+            :class="cn('xs:!flex-row flex flex-col justify-center gap-2')"
+          >
+            <BrandButton
+              v-for="item in extraLinks"
+              :key="item.text"
+              :variant="item.variant ?? undefined"
+              :href="item.href ?? undefined"
+              :icon="item.icon"
+              :icon-right="item.iconRight"
+              :icon-right-hover-display="item.iconRightHoverDisplay"
+              :text="t(item.text ?? '')"
+              :title="item.title ? t(item.title) : undefined"
+              @click="item.click?.()"
+            />
+          </div>
+
+          <div
+            v-if="updateOsIgnoredReleases.length > 0 && !(available || availableWithRenewal)"
+            class="mx-auto flex w-full max-w-[640px] flex-col gap-2"
+          >
+            <h3 class="text-left text-base font-semibold italic">
+              {{ t('updateOs.checkUpdateResponseModal.ignoredReleases') }}
+            </h3>
+            <UpdateOsIgnoredRelease
+              v-for="ignoredRelease in updateOsIgnoredReleases"
+              :key="ignoredRelease"
+              :label="ignoredRelease"
+              :t="t"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div
+        :class="
+          cn(
+            'mx-auto flex w-full gap-2',
+            actionButtons.length > 0 ? 'xs:!flex-row flex-col-reverse justify-between' : 'justify-center'
+          )
+        "
+      >
+        <div :class="cn('xs:!flex-row mt-2 flex flex-col-reverse justify-start gap-3')">
+          <TooltipProvider>
+            <Tooltip :delay-duration="0">
+              <TooltipTrigger as-child>
+                <Button variant="ghost" @click="accountStore.updateOs()">
+                  <ArrowTopRightOnSquareIcon class="mr-2 h-4 w-4" />
+                  {{ t('updateOs.checkUpdateResponseModal.moreOptions') }}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent class="max-w-xs">
+                <div class="flex items-start gap-2">
+                  <ArrowTopRightOnSquareIcon
+                    class="text-muted-foreground mt-0.5 h-4 w-4 flex-shrink-0"
+                  />
+                  <p class="text-left text-sm">
+                    {{
+                      t('updateOs.checkUpdateResponseModal.manageUpdatePreferencesIncludingBetaAccess')
+                    }}
+                  </p>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <div v-if="actionButtons.length > 0" :class="cn('xs:!flex-row flex flex-col justify-end gap-3')">
+          <BrandButton
+            v-for="item in actionButtons"
+            :key="item.text"
+            :variant="item.variant ?? undefined"
+            :icon="item.icon"
+            :icon-right="item.iconRight"
+            :icon-right-hover-display="item.iconRightHoverDisplay"
+            :text="item.text ?? ''"
+            :title="item.title ? item.title : undefined"
+            @click="item.click?.()"
+          />
+        </div>
+      </div>
+    </div>
+  </CardWrapper>
+
   <ResponsiveModal
+    v-else
     :open="open"
     :dialog-class="modalWidth"
     :sheet-class="'h-full'"

--- a/web/src/components/UpdateOs/Status.vue
+++ b/web/src/components/UpdateOs/Status.vue
@@ -74,6 +74,14 @@ const showRebootButton = computed(
   () => rebootType.value === 'downgrade' || rebootType.value === 'update'
 );
 
+const checkForUpdates = () => {
+  updateOsStore.localCheckForUpdate();
+};
+
+const showRefreshButton = computed(
+  () => updateAvailable.value && !showRebootButton.value && !props.showExternalDowngrade
+);
+
 const checkButton = computed(() => {
   if (showRebootButton.value || props.showExternalDowngrade) {
     return {
@@ -91,9 +99,7 @@ const checkButton = computed(() => {
 
   if (!updateAvailable.value) {
     return {
-      click: () => {
-        updateOsStore.localCheckForUpdate();
-      },
+      click: checkForUpdates,
       icon: () => h(ArrowPathIcon, { style: 'width: 16px; height: 16px;' }),
       text: t('userProfile.dropdownContent.checkForUpdate'),
     };
@@ -228,6 +234,17 @@ const navigateToRegistration = () => {
               ? t('updateOs.status.rebootNowToDowngradeTo', [rebootVersion])
               : t('updateOs.status.rebootNowToUpdateTo', [rebootVersion])
           }}
+        </Button>
+
+        <Button
+          v-if="showRefreshButton"
+          variant="pill-gray"
+          :title="t('userProfile.dropdownContent.checkForUpdate')"
+          :disabled="status === 'checking'"
+          @click="checkForUpdates"
+        >
+          <ArrowPathIcon class="shrink-0" style="width: 16px; height: 16px" />
+          {{ t('userProfile.dropdownContent.checkForUpdate') }}
         </Button>
 
         <Button


### PR DESCRIPTION
## Summary

- Render the internal Update OS status flow directly on `/Tools/Update` instead of showing an account-app redirect prompt.
- Automatically start the local update check on the Tools > Update OS page, or show the known update response when update data already exists.
- Render the update-check response inline on the page using the existing modal content in embedded mode, similar to the downgrade page's embedded workflow.
- Keep an explicit `Check for Update` action visible even when an update is already available, alongside the update CTA.
- Update the standalone component test expectations for the internal and embedded Tools page flow.

## Why

Users should be able to check for OS updates and use the internal updater from Tools > Update OS without leaving the OS. The previous landing prompt pushed them to the account app, and the update-check response appeared as a popup instead of as part of the page workflow.

## Validation

- `pnpm type-check` from `web/`
- `pnpm exec vitest run __test__/components/UpdateOs.test.ts __test__/components/CheckUpdateResponseModal.test.ts` from `web/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated "check for updates" button that appears when an update is available.
  * Improved update modal workflows with better organization of update information and responses.

* **Bug Fixes**
  * Removed outdated redirect prompt to streamline the update experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->