### PR TITLE
feat: add docker restart mutation

### DIFF
--- a/api/dev/configs/api.json
+++ b/api/dev/configs/api.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.29.2",
+  "version": "4.35.0",
   "extraOrigins": [],
   "sandbox": false,
   "ssoSubIds": [],

--- a/api/generated-schema.graphql
+++ b/api/generated-schema.graphql
@@ -1210,6 +1210,16 @@ type ArrayMutations {
 input ArrayStateInput {
   """Array state"""
   desiredState: ArrayStateInputState!
+
+  """
+  Optional password used to unlock encrypted array disks when starting the array
+  """
+  decryptionPassword: String
+
+  """
+  Optional keyfile contents used to unlock encrypted array disks when starting the array. Accepts a data URL or raw base64 payload.
+  """
+  decryptionKeyfile: String
 }
 
 enum ArrayStateInputState {
@@ -1231,6 +1241,9 @@ type DockerMutations {
 
   """Stop a container"""
   stop(id: PrefixedID!): DockerContainer!
+
+  """Restart a container"""
+  restart(id: PrefixedID!): DockerContainer!
 
   """Pause (Suspend) a container"""
   pause(id: PrefixedID!): DockerContainer!
@@ -2514,6 +2527,52 @@ type LogFileContent {
   startLine: Int
 }
 
+type NetworkMetrics implements Node {
+  id: PrefixedID!
+
+  """Interface identifier"""
+  name: String!
+
+  """Operational state"""
+  operstate: String
+
+  """Total received bytes"""
+  bytesReceived: BigInt!
+
+  """Total transmitted bytes"""
+  bytesSent: BigInt!
+
+  """Total received packets"""
+  packetsReceived: BigInt!
+
+  """Total transmitted packets"""
+  packetsSent: BigInt!
+
+  """Receive errors"""
+  receiveErrors: BigInt!
+
+  """Transmit errors"""
+  transmitErrors: BigInt!
+
+  """Dropped receive packets"""
+  receiveDropped: BigInt!
+
+  """Dropped transmit packets"""
+  transmitDropped: BigInt!
+
+  """Receive throughput in bytes per second"""
+  rxSec: Float!
+
+  """Transmit throughput in bytes per second"""
+  txSec: Float!
+
+  """Estimated link utilization percentage"""
+  utilizationPercent: Float
+
+  """Metric collection timestamp"""
+  lastUpdated: DateTime!
+}
+
 type TemperatureReading {
   """Temperature value"""
   value: Float!
@@ -2612,52 +2671,6 @@ type TemperatureMetrics implements Node {
 
   """Temperature summary"""
   summary: TemperatureSummary!
-}
-
-type NetworkMetrics implements Node {
-  id: PrefixedID!
-
-  """Interface identifier"""
-  name: String!
-
-  """Operational state"""
-  operstate: String
-
-  """Total received bytes"""
-  bytesReceived: BigInt!
-
-  """Total transmitted bytes"""
-  bytesSent: BigInt!
-
-  """Total received packets"""
-  packetsReceived: BigInt!
-
-  """Total transmitted packets"""
-  packetsSent: BigInt!
-
-  """Receive errors"""
-  receiveErrors: BigInt!
-
-  """Transmit errors"""
-  transmitErrors: BigInt!
-
-  """Dropped receive packets"""
-  receiveDropped: BigInt!
-
-  """Dropped transmit packets"""
-  transmitDropped: BigInt!
-
-  """Receive throughput in bytes per second"""
-  rxSec: Float!
-
-  """Transmit throughput in bytes per second"""
-  txSec: Float!
-
-  """Estimated link utilization percentage"""
-  utilizationPercent: Float
-
-  """Metric collection timestamp"""
-  lastUpdated: DateTime!
 }
 
 """System metrics including CPU and memory utilization"""
@@ -3315,6 +3328,9 @@ type Query {
   isFreshInstall: Boolean!
   publicTheme: Theme!
   info: Info!
+
+  """Network interfaces"""
+  networkInterfaces: [InfoNetworkInterface!]!
   docker: Docker!
   disks: [Disk!]!
   assignableDisks: [Disk!]!
@@ -3339,9 +3355,6 @@ type Query {
 
   """Validate an OIDC session token (internal use for CLI validation)"""
   validateOidcSession(token: String!): OidcSessionValidation!
-
-  """Network interfaces"""
-  networkInterfaces: [InfoNetworkInterface!]!
   metrics: Metrics!
 
   """Retrieve current system time configuration"""

--- a/api/generated-schema.graphql
+++ b/api/generated-schema.graphql
@@ -1210,6 +1210,16 @@ type ArrayMutations {
 input ArrayStateInput {
   """Array state"""
   desiredState: ArrayStateInputState!
+
+  """
+  Optional password used to unlock encrypted array disks when starting the array
+  """
+  decryptionPassword: String
+
+  """
+  Optional keyfile contents used to unlock encrypted array disks when starting the array. Accepts a data URL or raw base64 payload.
+  """
+  decryptionKeyfile: String
 }
 
 enum ArrayStateInputState {
@@ -1231,6 +1241,9 @@ type DockerMutations {
 
   """Stop a container"""
   stop(id: PrefixedID!): DockerContainer!
+
+  """Restart a container"""
+  restart(id: PrefixedID!): DockerContainer!
 
   """Pause (Suspend) a container"""
   pause(id: PrefixedID!): DockerContainer!
@@ -2514,6 +2527,52 @@ type LogFileContent {
   startLine: Int
 }
 
+type NetworkMetrics implements Node {
+  id: PrefixedID!
+
+  """Interface identifier"""
+  name: String!
+
+  """Operational state"""
+  operstate: String
+
+  """Total received bytes"""
+  bytesReceived: BigInt!
+
+  """Total transmitted bytes"""
+  bytesSent: BigInt!
+
+  """Total received packets"""
+  packetsReceived: BigInt!
+
+  """Total transmitted packets"""
+  packetsSent: BigInt!
+
+  """Receive errors"""
+  receiveErrors: BigInt!
+
+  """Transmit errors"""
+  transmitErrors: BigInt!
+
+  """Dropped receive packets"""
+  receiveDropped: BigInt!
+
+  """Dropped transmit packets"""
+  transmitDropped: BigInt!
+
+  """Receive throughput in bytes per second"""
+  rxSec: Float!
+
+  """Transmit throughput in bytes per second"""
+  txSec: Float!
+
+  """Estimated link utilization percentage"""
+  utilizationPercent: Float
+
+  """Metric collection timestamp"""
+  lastUpdated: DateTime!
+}
+
 type TemperatureReading {
   """Temperature value"""
   value: Float!
@@ -2612,52 +2671,6 @@ type TemperatureMetrics implements Node {
 
   """Temperature summary"""
   summary: TemperatureSummary!
-}
-
-type NetworkMetrics implements Node {
-  id: PrefixedID!
-
-  """Interface identifier"""
-  name: String!
-
-  """Operational state"""
-  operstate: String
-
-  """Total received bytes"""
-  bytesReceived: BigInt!
-
-  """Total transmitted bytes"""
-  bytesSent: BigInt!
-
-  """Total received packets"""
-  packetsReceived: BigInt!
-
-  """Total transmitted packets"""
-  packetsSent: BigInt!
-
-  """Receive errors"""
-  receiveErrors: BigInt!
-
-  """Transmit errors"""
-  transmitErrors: BigInt!
-
-  """Dropped receive packets"""
-  receiveDropped: BigInt!
-
-  """Dropped transmit packets"""
-  transmitDropped: BigInt!
-
-  """Receive throughput in bytes per second"""
-  rxSec: Float!
-
-  """Transmit throughput in bytes per second"""
-  txSec: Float!
-
-  """Estimated link utilization percentage"""
-  utilizationPercent: Float
-
-  """Metric collection timestamp"""
-  lastUpdated: DateTime!
 }
 
 """System metrics including CPU and memory utilization"""
@@ -3106,160 +3119,6 @@ type Plugin {
   hasCliModule: Boolean
 }
 
-type AccessUrl {
-  type: URL_TYPE!
-  name: String
-  ipv4: URL
-  ipv6: URL
-}
-
-enum URL_TYPE {
-  LAN
-  WIREGUARD
-  WAN
-  MDNS
-  OTHER
-  DEFAULT
-}
-
-"""
-A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.
-"""
-scalar URL
-
-type AccessUrlObject {
-  ipv4: String
-  ipv6: String
-  type: URL_TYPE!
-  name: String
-}
-
-type ApiKeyResponse {
-  valid: Boolean!
-  error: String
-}
-
-type MinigraphqlResponse {
-  status: MinigraphStatus!
-  timeout: Int
-  error: String
-}
-
-"""The status of the minigraph"""
-enum MinigraphStatus {
-  PRE_INIT
-  CONNECTING
-  CONNECTED
-  PING_FAILURE
-  ERROR_RETRYING
-}
-
-type CloudResponse {
-  status: String!
-  ip: String
-  error: String
-}
-
-type RelayResponse {
-  status: String!
-  timeout: String
-  error: String
-}
-
-type Cloud {
-  error: String
-  apiKey: ApiKeyResponse!
-  relay: RelayResponse
-  minigraphql: MinigraphqlResponse!
-  cloud: CloudResponse!
-  allowedOrigins: [String!]!
-}
-
-type RemoteAccess {
-  """The type of WAN access used for Remote Access"""
-  accessType: WAN_ACCESS_TYPE!
-
-  """The type of port forwarding used for Remote Access"""
-  forwardType: WAN_FORWARD_TYPE
-
-  """The port used for Remote Access"""
-  port: Int
-}
-
-enum WAN_ACCESS_TYPE {
-  DYNAMIC
-  ALWAYS
-  DISABLED
-}
-
-enum WAN_FORWARD_TYPE {
-  UPNP
-  STATIC
-}
-
-type DynamicRemoteAccessStatus {
-  """The type of dynamic remote access that is enabled"""
-  enabledType: DynamicRemoteAccessType!
-
-  """The type of dynamic remote access that is currently running"""
-  runningType: DynamicRemoteAccessType!
-
-  """Any error message associated with the dynamic remote access"""
-  error: String
-}
-
-enum DynamicRemoteAccessType {
-  STATIC
-  UPNP
-  DISABLED
-}
-
-type ConnectSettingsValues {
-  """The type of WAN access used for Remote Access"""
-  accessType: WAN_ACCESS_TYPE!
-
-  """The type of port forwarding used for Remote Access"""
-  forwardType: WAN_FORWARD_TYPE
-
-  """The port used for Remote Access"""
-  port: Int
-}
-
-type ConnectSettings implements Node {
-  id: PrefixedID!
-
-  """The data schema for the Connect settings"""
-  dataSchema: JSON!
-
-  """The UI schema for the Connect settings"""
-  uiSchema: JSON!
-
-  """The values for the Connect settings"""
-  values: ConnectSettingsValues!
-}
-
-type Connect implements Node {
-  id: PrefixedID!
-
-  """The status of dynamic remote access"""
-  dynamicRemoteAccess: DynamicRemoteAccessStatus!
-
-  """The settings for the Connect instance"""
-  settings: ConnectSettings!
-}
-
-type Network implements Node {
-  id: PrefixedID!
-  accessUrls: [AccessUrl!]
-}
-
-input AccessUrlObjectInput {
-  ipv4: String
-  ipv6: String
-  type: URL_TYPE!
-  name: String
-}
-
 "\n### Description:\n\nID scalar type that prefixes the underlying ID with the server identifier on output and strips it on input.\n\nWe use this scalar type to ensure that the ID is unique across all servers, allowing the same underlying resource ID to be used across different server instances.\n\n#### Input Behavior:\n\nWhen providing an ID as input (e.g., in arguments or input objects), the server identifier prefix ('<serverId>:') is optional.\n\n- If the prefix is present (e.g., '123:456'), it will be automatically stripped, and only the underlying ID ('456') will be used internally.\n- If the prefix is absent (e.g., '456'), the ID will be used as-is.\n\nThis makes it flexible for clients, as they don't strictly need to know or provide the server ID.\n\n#### Output Behavior:\n\nWhen an ID is returned in the response (output), it will *always* be prefixed with the current server's unique identifier (e.g., '123:456').\n\n#### Example:\n\nNote: The server identifier is '123' in this example.\n\n##### Input (Prefix Optional):\n```graphql\n# Both of these are valid inputs resolving to internal ID '456'\n{\n  someQuery(id: \"123:456\") { ... }\n  anotherQuery(id: \"456\") { ... }\n}\n```\n\n##### Output (Prefix Always Added):\n```graphql\n# Assuming internal ID is '456'\n{\n  \"data\": {\n    \"someResource\": {\n      \"id\": \"123:456\" \n    }\n  }\n}\n```\n        "
 scalar PrefixedID
 
@@ -3315,6 +3174,9 @@ type Query {
   isFreshInstall: Boolean!
   publicTheme: Theme!
   info: Info!
+
+  """Network interfaces"""
+  networkInterfaces: [InfoNetworkInterface!]!
   docker: Docker!
   disks: [Disk!]!
   assignableDisks: [Disk!]!
@@ -3339,9 +3201,6 @@ type Query {
 
   """Validate an OIDC session token (internal use for CLI validation)"""
   validateOidcSession(token: String!): OidcSessionValidation!
-
-  """Network interfaces"""
-  networkInterfaces: [InfoNetworkInterface!]!
   metrics: Metrics!
 
   """Retrieve current system time configuration"""
@@ -3364,10 +3223,6 @@ type Query {
 
   """List all installed plugins with their metadata"""
   plugins: [Plugin!]!
-  remoteAccess: RemoteAccess!
-  connect: Connect!
-  network: Network!
-  cloud: Cloud!
 }
 
 type Mutation {
@@ -3442,11 +3297,6 @@ type Mutation {
   Remove one or more plugins from the API. Returns false if restart was triggered automatically, true if manual restart is required.
   """
   removePlugin(input: PluginManagementInput!): Boolean!
-  updateApiSettings(input: ConnectSettingsInput!): ConnectSettingsValues!
-  connectSignIn(input: ConnectSignInInput!): Boolean!
-  connectSignOut: Boolean!
-  setupRemoteAccess(input: SetupRemoteAccessInput!): Boolean!
-  enableDynamicRemoteAccess(input: EnableDynamicRemoteAccessInput!): Boolean!
 }
 
 input NotificationData {
@@ -3630,66 +3480,6 @@ input PluginManagementInput {
   Whether to restart the API after the operation. When false, a restart has already been queued.
   """
   restart: Boolean! = true
-}
-
-input ConnectSettingsInput {
-  """The type of WAN access to use for Remote Access"""
-  accessType: WAN_ACCESS_TYPE
-
-  """The type of port forwarding to use for Remote Access"""
-  forwardType: WAN_FORWARD_TYPE
-
-  """
-  The port to use for Remote Access. Not required for UPNP forwardType. Required for STATIC forwardType. Ignored if accessType is DISABLED or forwardType is UPNP.
-  """
-  port: Int
-}
-
-input ConnectSignInInput {
-  """The API key for authentication"""
-  apiKey: String!
-
-  """User information for the sign-in"""
-  userInfo: ConnectUserInfoInput
-}
-
-input ConnectUserInfoInput {
-  """The preferred username of the user"""
-  preferred_username: String!
-
-  """The email address of the user"""
-  email: String!
-
-  """The avatar URL of the user"""
-  avatar: String
-}
-
-input SetupRemoteAccessInput {
-  """The type of WAN access to use for Remote Access"""
-  accessType: WAN_ACCESS_TYPE!
-
-  """The type of port forwarding to use for Remote Access"""
-  forwardType: WAN_FORWARD_TYPE
-
-  """
-  The port to use for Remote Access. Not required for UPNP forwardType. Required for STATIC forwardType. Ignored if accessType is DISABLED or forwardType is UPNP.
-  """
-  port: Int
-}
-
-input EnableDynamicRemoteAccessInput {
-  """The AccessURL Input for dynamic remote access"""
-  url: AccessUrlInput!
-
-  """Whether to enable or disable dynamic remote access"""
-  enabled: Boolean!
-}
-
-input AccessUrlInput {
-  type: URL_TYPE!
-  name: String
-  ipv4: URL
-  ipv6: URL
 }
 
 type Subscription {

--- a/api/generated-schema.graphql
+++ b/api/generated-schema.graphql
@@ -1210,16 +1210,6 @@ type ArrayMutations {
 input ArrayStateInput {
   """Array state"""
   desiredState: ArrayStateInputState!
-
-  """
-  Optional password used to unlock encrypted array disks when starting the array
-  """
-  decryptionPassword: String
-
-  """
-  Optional keyfile contents used to unlock encrypted array disks when starting the array. Accepts a data URL or raw base64 payload.
-  """
-  decryptionKeyfile: String
 }
 
 enum ArrayStateInputState {
@@ -1241,9 +1231,6 @@ type DockerMutations {
 
   """Stop a container"""
   stop(id: PrefixedID!): DockerContainer!
-
-  """Restart a container"""
-  restart(id: PrefixedID!): DockerContainer!
 
   """Pause (Suspend) a container"""
   pause(id: PrefixedID!): DockerContainer!
@@ -2527,52 +2514,6 @@ type LogFileContent {
   startLine: Int
 }
 
-type NetworkMetrics implements Node {
-  id: PrefixedID!
-
-  """Interface identifier"""
-  name: String!
-
-  """Operational state"""
-  operstate: String
-
-  """Total received bytes"""
-  bytesReceived: BigInt!
-
-  """Total transmitted bytes"""
-  bytesSent: BigInt!
-
-  """Total received packets"""
-  packetsReceived: BigInt!
-
-  """Total transmitted packets"""
-  packetsSent: BigInt!
-
-  """Receive errors"""
-  receiveErrors: BigInt!
-
-  """Transmit errors"""
-  transmitErrors: BigInt!
-
-  """Dropped receive packets"""
-  receiveDropped: BigInt!
-
-  """Dropped transmit packets"""
-  transmitDropped: BigInt!
-
-  """Receive throughput in bytes per second"""
-  rxSec: Float!
-
-  """Transmit throughput in bytes per second"""
-  txSec: Float!
-
-  """Estimated link utilization percentage"""
-  utilizationPercent: Float
-
-  """Metric collection timestamp"""
-  lastUpdated: DateTime!
-}
-
 type TemperatureReading {
   """Temperature value"""
   value: Float!
@@ -2671,6 +2612,52 @@ type TemperatureMetrics implements Node {
 
   """Temperature summary"""
   summary: TemperatureSummary!
+}
+
+type NetworkMetrics implements Node {
+  id: PrefixedID!
+
+  """Interface identifier"""
+  name: String!
+
+  """Operational state"""
+  operstate: String
+
+  """Total received bytes"""
+  bytesReceived: BigInt!
+
+  """Total transmitted bytes"""
+  bytesSent: BigInt!
+
+  """Total received packets"""
+  packetsReceived: BigInt!
+
+  """Total transmitted packets"""
+  packetsSent: BigInt!
+
+  """Receive errors"""
+  receiveErrors: BigInt!
+
+  """Transmit errors"""
+  transmitErrors: BigInt!
+
+  """Dropped receive packets"""
+  receiveDropped: BigInt!
+
+  """Dropped transmit packets"""
+  transmitDropped: BigInt!
+
+  """Receive throughput in bytes per second"""
+  rxSec: Float!
+
+  """Transmit throughput in bytes per second"""
+  txSec: Float!
+
+  """Estimated link utilization percentage"""
+  utilizationPercent: Float
+
+  """Metric collection timestamp"""
+  lastUpdated: DateTime!
 }
 
 """System metrics including CPU and memory utilization"""
@@ -3119,6 +3106,160 @@ type Plugin {
   hasCliModule: Boolean
 }
 
+type AccessUrl {
+  type: URL_TYPE!
+  name: String
+  ipv4: URL
+  ipv6: URL
+}
+
+enum URL_TYPE {
+  LAN
+  WIREGUARD
+  WAN
+  MDNS
+  OTHER
+  DEFAULT
+}
+
+"""
+A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.
+"""
+scalar URL
+
+type AccessUrlObject {
+  ipv4: String
+  ipv6: String
+  type: URL_TYPE!
+  name: String
+}
+
+type ApiKeyResponse {
+  valid: Boolean!
+  error: String
+}
+
+type MinigraphqlResponse {
+  status: MinigraphStatus!
+  timeout: Int
+  error: String
+}
+
+"""The status of the minigraph"""
+enum MinigraphStatus {
+  PRE_INIT
+  CONNECTING
+  CONNECTED
+  PING_FAILURE
+  ERROR_RETRYING
+}
+
+type CloudResponse {
+  status: String!
+  ip: String
+  error: String
+}
+
+type RelayResponse {
+  status: String!
+  timeout: String
+  error: String
+}
+
+type Cloud {
+  error: String
+  apiKey: ApiKeyResponse!
+  relay: RelayResponse
+  minigraphql: MinigraphqlResponse!
+  cloud: CloudResponse!
+  allowedOrigins: [String!]!
+}
+
+type RemoteAccess {
+  """The type of WAN access used for Remote Access"""
+  accessType: WAN_ACCESS_TYPE!
+
+  """The type of port forwarding used for Remote Access"""
+  forwardType: WAN_FORWARD_TYPE
+
+  """The port used for Remote Access"""
+  port: Int
+}
+
+enum WAN_ACCESS_TYPE {
+  DYNAMIC
+  ALWAYS
+  DISABLED
+}
+
+enum WAN_FORWARD_TYPE {
+  UPNP
+  STATIC
+}
+
+type DynamicRemoteAccessStatus {
+  """The type of dynamic remote access that is enabled"""
+  enabledType: DynamicRemoteAccessType!
+
+  """The type of dynamic remote access that is currently running"""
+  runningType: DynamicRemoteAccessType!
+
+  """Any error message associated with the dynamic remote access"""
+  error: String
+}
+
+enum DynamicRemoteAccessType {
+  STATIC
+  UPNP
+  DISABLED
+}
+
+type ConnectSettingsValues {
+  """The type of WAN access used for Remote Access"""
+  accessType: WAN_ACCESS_TYPE!
+
+  """The type of port forwarding used for Remote Access"""
+  forwardType: WAN_FORWARD_TYPE
+
+  """The port used for Remote Access"""
+  port: Int
+}
+
+type ConnectSettings implements Node {
+  id: PrefixedID!
+
+  """The data schema for the Connect settings"""
+  dataSchema: JSON!
+
+  """The UI schema for the Connect settings"""
+  uiSchema: JSON!
+
+  """The values for the Connect settings"""
+  values: ConnectSettingsValues!
+}
+
+type Connect implements Node {
+  id: PrefixedID!
+
+  """The status of dynamic remote access"""
+  dynamicRemoteAccess: DynamicRemoteAccessStatus!
+
+  """The settings for the Connect instance"""
+  settings: ConnectSettings!
+}
+
+type Network implements Node {
+  id: PrefixedID!
+  accessUrls: [AccessUrl!]
+}
+
+input AccessUrlObjectInput {
+  ipv4: String
+  ipv6: String
+  type: URL_TYPE!
+  name: String
+}
+
 "\n### Description:\n\nID scalar type that prefixes the underlying ID with the server identifier on output and strips it on input.\n\nWe use this scalar type to ensure that the ID is unique across all servers, allowing the same underlying resource ID to be used across different server instances.\n\n#### Input Behavior:\n\nWhen providing an ID as input (e.g., in arguments or input objects), the server identifier prefix ('<serverId>:') is optional.\n\n- If the prefix is present (e.g., '123:456'), it will be automatically stripped, and only the underlying ID ('456') will be used internally.\n- If the prefix is absent (e.g., '456'), the ID will be used as-is.\n\nThis makes it flexible for clients, as they don't strictly need to know or provide the server ID.\n\n#### Output Behavior:\n\nWhen an ID is returned in the response (output), it will *always* be prefixed with the current server's unique identifier (e.g., '123:456').\n\n#### Example:\n\nNote: The server identifier is '123' in this example.\n\n##### Input (Prefix Optional):\n```graphql\n# Both of these are valid inputs resolving to internal ID '456'\n{\n  someQuery(id: \"123:456\") { ... }\n  anotherQuery(id: \"456\") { ... }\n}\n```\n\n##### Output (Prefix Always Added):\n```graphql\n# Assuming internal ID is '456'\n{\n  \"data\": {\n    \"someResource\": {\n      \"id\": \"123:456\" \n    }\n  }\n}\n```\n        "
 scalar PrefixedID
 
@@ -3174,9 +3315,6 @@ type Query {
   isFreshInstall: Boolean!
   publicTheme: Theme!
   info: Info!
-
-  """Network interfaces"""
-  networkInterfaces: [InfoNetworkInterface!]!
   docker: Docker!
   disks: [Disk!]!
   assignableDisks: [Disk!]!
@@ -3201,6 +3339,9 @@ type Query {
 
   """Validate an OIDC session token (internal use for CLI validation)"""
   validateOidcSession(token: String!): OidcSessionValidation!
+
+  """Network interfaces"""
+  networkInterfaces: [InfoNetworkInterface!]!
   metrics: Metrics!
 
   """Retrieve current system time configuration"""
@@ -3223,6 +3364,10 @@ type Query {
 
   """List all installed plugins with their metadata"""
   plugins: [Plugin!]!
+  remoteAccess: RemoteAccess!
+  connect: Connect!
+  network: Network!
+  cloud: Cloud!
 }
 
 type Mutation {
@@ -3297,6 +3442,11 @@ type Mutation {
   Remove one or more plugins from the API. Returns false if restart was triggered automatically, true if manual restart is required.
   """
   removePlugin(input: PluginManagementInput!): Boolean!
+  updateApiSettings(input: ConnectSettingsInput!): ConnectSettingsValues!
+  connectSignIn(input: ConnectSignInInput!): Boolean!
+  connectSignOut: Boolean!
+  setupRemoteAccess(input: SetupRemoteAccessInput!): Boolean!
+  enableDynamicRemoteAccess(input: EnableDynamicRemoteAccessInput!): Boolean!
 }
 
 input NotificationData {
@@ -3480,6 +3630,66 @@ input PluginManagementInput {
   Whether to restart the API after the operation. When false, a restart has already been queued.
   """
   restart: Boolean! = true
+}
+
+input ConnectSettingsInput {
+  """The type of WAN access to use for Remote Access"""
+  accessType: WAN_ACCESS_TYPE
+
+  """The type of port forwarding to use for Remote Access"""
+  forwardType: WAN_FORWARD_TYPE
+
+  """
+  The port to use for Remote Access. Not required for UPNP forwardType. Required for STATIC forwardType. Ignored if accessType is DISABLED or forwardType is UPNP.
+  """
+  port: Int
+}
+
+input ConnectSignInInput {
+  """The API key for authentication"""
+  apiKey: String!
+
+  """User information for the sign-in"""
+  userInfo: ConnectUserInfoInput
+}
+
+input ConnectUserInfoInput {
+  """The preferred username of the user"""
+  preferred_username: String!
+
+  """The email address of the user"""
+  email: String!
+
+  """The avatar URL of the user"""
+  avatar: String
+}
+
+input SetupRemoteAccessInput {
+  """The type of WAN access to use for Remote Access"""
+  accessType: WAN_ACCESS_TYPE!
+
+  """The type of port forwarding to use for Remote Access"""
+  forwardType: WAN_FORWARD_TYPE
+
+  """
+  The port to use for Remote Access. Not required for UPNP forwardType. Required for STATIC forwardType. Ignored if accessType is DISABLED or forwardType is UPNP.
+  """
+  port: Int
+}
+
+input EnableDynamicRemoteAccessInput {
+  """The AccessURL Input for dynamic remote access"""
+  url: AccessUrlInput!
+
+  """Whether to enable or disable dynamic remote access"""
+  enabled: Boolean!
+}
+
+input AccessUrlInput {
+  type: URL_TYPE!
+  name: String
+  ipv4: URL
+  ipv6: URL
 }
 
 type Subscription {

--- a/api/src/unraid-api/cli/generated/graphql.ts
+++ b/api/src/unraid-api/cli/generated/graphql.ts
@@ -1311,31 +1311,69 @@ export type InfoNetworkInterface = Node & {
   __typename?: 'InfoNetworkInterface';
   /** Interface description/label */
   description?: Maybe<Scalars['String']['output']>;
+  /** Link duplex mode */
+  duplex?: Maybe<Scalars['String']['output']>;
   /** IPv4 Gateway */
   gateway?: Maybe<Scalars['String']['output']>;
   id: Scalars['PrefixedID']['output'];
+  /** Whether this is an internal interface */
+  internal?: Maybe<Scalars['Boolean']['output']>;
   /** IPv4 Address */
   ipAddress?: Maybe<Scalars['String']['output']>;
+  /** IPv4 addresses assigned to this interface */
+  ipv4Addresses: Array<InfoNetworkIpv4Address>;
   /** IPv6 Address */
   ipv6Address?: Maybe<Scalars['String']['output']>;
+  /** IPv6 addresses assigned to this interface */
+  ipv6Addresses: Array<InfoNetworkIpv6Address>;
   /** IPv6 Gateway */
   ipv6Gateway?: Maybe<Scalars['String']['output']>;
   /** IPv6 Netmask */
   ipv6Netmask?: Maybe<Scalars['String']['output']>;
   /** MAC Address */
   macAddress?: Maybe<Scalars['String']['output']>;
+  /** Maximum transmission unit */
+  mtu?: Maybe<Scalars['Int']['output']>;
   /** Interface name (e.g. eth0) */
   name: Scalars['String']['output'];
   /** IPv4 Netmask */
   netmask?: Maybe<Scalars['String']['output']>;
+  /** Operational state */
+  operstate?: Maybe<Scalars['String']['output']>;
   /** IPv4 Protocol mode */
   protocol?: Maybe<Scalars['String']['output']>;
+  /** Link speed in Mbps */
+  speed?: Maybe<Scalars['Int']['output']>;
   /** Connection status */
   status?: Maybe<Scalars['String']['output']>;
+  /** Interface type */
+  type?: Maybe<Scalars['String']['output']>;
   /** Using DHCP for IPv4 */
   useDhcp?: Maybe<Scalars['Boolean']['output']>;
   /** Using DHCP for IPv6 */
   useDhcp6?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether this is a virtual interface */
+  virtual?: Maybe<Scalars['Boolean']['output']>;
+  /** VLAN identifier parsed from the interface name */
+  vlanId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** IPv4 address assigned to a network interface */
+export type InfoNetworkIpv4Address = {
+  __typename?: 'InfoNetworkIpv4Address';
+  /** IPv4 address */
+  address: Scalars['String']['output'];
+  /** IPv4 netmask */
+  netmask: Scalars['String']['output'];
+};
+
+/** IPv6 address assigned to a network interface */
+export type InfoNetworkIpv6Address = {
+  __typename?: 'InfoNetworkIpv6Address';
+  /** IPv6 address */
+  address: Scalars['String']['output'];
+  /** IPv6 prefix length */
+  prefixLength?: Maybe<Scalars['Int']['output']>;
 };
 
 export type InfoOs = Node & {
@@ -1576,6 +1614,8 @@ export type Metrics = Node & {
   id: Scalars['PrefixedID']['output'];
   /** Current memory utilization metrics */
   memory?: Maybe<MemoryUtilization>;
+  /** Current network metrics for all interfaces */
+  network: Array<NetworkMetrics>;
   /** Temperature metrics */
   temperature?: Maybe<TemperatureMetrics>;
 };
@@ -1827,6 +1867,39 @@ export type Network = Node & {
   id: Scalars['PrefixedID']['output'];
 };
 
+export type NetworkMetrics = Node & {
+  __typename?: 'NetworkMetrics';
+  /** Total received bytes */
+  bytesReceived: Scalars['BigInt']['output'];
+  /** Total transmitted bytes */
+  bytesSent: Scalars['BigInt']['output'];
+  id: Scalars['PrefixedID']['output'];
+  /** Metric collection timestamp */
+  lastUpdated: Scalars['DateTime']['output'];
+  /** Interface identifier */
+  name: Scalars['String']['output'];
+  /** Operational state */
+  operstate?: Maybe<Scalars['String']['output']>;
+  /** Total received packets */
+  packetsReceived: Scalars['BigInt']['output'];
+  /** Total transmitted packets */
+  packetsSent: Scalars['BigInt']['output'];
+  /** Dropped receive packets */
+  receiveDropped: Scalars['BigInt']['output'];
+  /** Receive errors */
+  receiveErrors: Scalars['BigInt']['output'];
+  /** Receive throughput in bytes per second */
+  rxSec: Scalars['Float']['output'];
+  /** Dropped transmit packets */
+  transmitDropped: Scalars['BigInt']['output'];
+  /** Transmit errors */
+  transmitErrors: Scalars['BigInt']['output'];
+  /** Transmit throughput in bytes per second */
+  txSec: Scalars['Float']['output'];
+  /** Estimated link utilization percentage */
+  utilizationPercent?: Maybe<Scalars['Float']['output']>;
+};
+
 export type Node = {
   id: Scalars['PrefixedID']['output'];
 };
@@ -1985,10 +2058,19 @@ export type OnboardingInternalBootContext = {
   assignableDisks: Array<Disk>;
   bootEligible?: Maybe<Scalars['Boolean']['output']>;
   bootedFromFlashWithInternalBootSetup: Scalars['Boolean']['output'];
+  driveWarnings: Array<OnboardingInternalBootDriveWarning>;
   enableBootTransfer?: Maybe<Scalars['String']['output']>;
   poolNames: Array<Scalars['String']['output']>;
   reservedNames: Array<Scalars['String']['output']>;
   shareNames: Array<Scalars['String']['output']>;
+};
+
+/** Warning metadata for an assignable internal boot drive */
+export type OnboardingInternalBootDriveWarning = {
+  __typename?: 'OnboardingInternalBootDriveWarning';
+  device: Scalars['String']['output'];
+  diskId: Scalars['String']['output'];
+  warnings: Array<Scalars['String']['output']>;
 };
 
 /** Result of attempting internal boot pool setup */
@@ -2318,6 +2400,8 @@ export type Query = {
   me: UserAccount;
   metrics: Metrics;
   network: Network;
+  /** Network interfaces */
+  networkInterfaces: Array<InfoNetworkInterface>;
   /** Get all notifications */
   notifications: Notifications;
   /** Get the full OIDC configuration (admin only) */
@@ -2727,6 +2811,7 @@ export type Subscription = {
   systemMetricsCpu: CpuUtilization;
   systemMetricsCpuTelemetry: CpuPackages;
   systemMetricsMemory: MemoryUtilization;
+  systemMetricsNetwork: Array<NetworkMetrics>;
   systemMetricsTemperature?: Maybe<TemperatureMetrics>;
   upsUpdates: UpsDevice;
 };

--- a/api/src/unraid-api/cli/generated/graphql.ts
+++ b/api/src/unraid-api/cli/generated/graphql.ts
@@ -366,6 +366,10 @@ export enum ArrayState {
 }
 
 export type ArrayStateInput = {
+  /** Optional keyfile contents used to unlock encrypted array disks when starting the array. Accepts a data URL or raw base64 payload. */
+  decryptionKeyfile?: InputMaybe<Scalars['String']['input']>;
+  /** Optional password used to unlock encrypted array disks when starting the array */
+  decryptionPassword?: InputMaybe<Scalars['String']['input']>;
   /** Array state */
   desiredState: ArrayStateInputState;
 };
@@ -948,6 +952,8 @@ export type DockerMutations = {
   pause: DockerContainer;
   /** Remove a container */
   removeContainer: Scalars['Boolean']['output'];
+  /** Restart a container */
+  restart: DockerContainer;
   /** Start a container */
   start: DockerContainer;
   /** Stop a container */
@@ -973,6 +979,11 @@ export type DockerMutationsPauseArgs = {
 export type DockerMutationsRemoveContainerArgs = {
   id: Scalars['PrefixedID']['input'];
   withImage?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type DockerMutationsRestartArgs = {
+  id: Scalars['PrefixedID']['input'];
 };
 
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.spec.ts
@@ -20,6 +20,7 @@ describe('DockerMutationsResolver', () => {
                     useValue: {
                         start: vi.fn(),
                         stop: vi.fn(),
+                        restart: vi.fn(),
                     },
                 },
             ],
@@ -52,6 +53,27 @@ describe('DockerMutationsResolver', () => {
         const result = await resolver.start('1');
         expect(result).toEqual(mockContainer);
         expect(dockerService.start).toHaveBeenCalledWith('1');
+    });
+
+    it('should restart', async () => {
+        const mockContainer: DockerContainer = {
+            id: '1',
+            autoStart: false,
+            command: 'test',
+            created: 1234567890,
+            image: 'test-image',
+            imageId: 'test-image-id',
+            ports: [],
+            state: ContainerState.RUNNING,
+            status: 'Up 2 seconds',
+            names: ['test-container'],
+            isOrphaned: false,
+        };
+        vi.mocked(dockerService.restart).mockResolvedValue(mockContainer);
+
+        const result = await resolver.restart('1');
+        expect(result).toEqual(mockContainer);
+        expect(dockerService.restart).toHaveBeenCalledWith('1');
     });
 
     it('should stop', async () => {

--- a/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.mutations.resolver.ts
@@ -36,6 +36,15 @@ export class DockerMutationsResolver {
     public async stop(@Args('id', { type: () => PrefixedID }) id: string) {
         return this.dockerService.stop(id);
     }
+    @ResolveField(() => DockerContainer, { description: 'Restart a container' })
+    @UsePermissions({
+        action: AuthAction.UPDATE_ANY,
+        resource: Resource.DOCKER,
+    })
+    public async restart(@Args('id', { type: () => PrefixedID }) id: string) {
+        return this.dockerService.restart(id);
+    }
+
     @ResolveField(() => DockerContainer, { description: 'Pause (Suspend) a container' })
     @UsePermissions({
         action: AuthAction.UPDATE_ANY,

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -176,6 +176,7 @@ describe('DockerService', () => {
         mockContainer.stop.mockReset();
         mockContainer.pause.mockReset();
         mockContainer.unpause.mockReset();
+        mockContainer.restart.mockReset();
         mockContainer.inspect.mockReset();
 
         statMock.mockReset();

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -78,6 +78,10 @@ vi.mock('execa', () => ({
     execa: vi.fn(),
 }));
 
+vi.mock('@app/core/utils/misc/sleep.js', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
 const { mockEmhttpGetter } = vi.hoisted(() => ({
     mockEmhttpGetter: vi.fn().mockReturnValue({
         networks: [],
@@ -375,6 +379,51 @@ describe('DockerService', () => {
             expect(mockDockerPortService.deduplicateContainerPorts).toHaveBeenCalledWith(
                 container.Ports
             );
+        });
+    });
+
+    describe('restart', () => {
+        const containerInfo = {
+            Id: 'abc123',
+            Names: ['/test-container'],
+            Image: 'test-image',
+            ImageID: 'sha256:abc',
+            Command: 'test',
+            Created: 1700000000,
+            Status: 'Up',
+            Ports: [],
+            Labels: {},
+            HostConfig: { NetworkMode: 'bridge' },
+            NetworkSettings: { Networks: {} },
+            Mounts: [],
+        };
+
+        it('returns the container when it reaches RUNNING state', async () => {
+            mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'running' }]);
+            mockContainer.restart.mockResolvedValue(undefined);
+
+            const result = await service.restart('abc123');
+
+            expect(mockContainer.restart).toHaveBeenCalledWith({ t: 10 });
+            expect(result).toMatchObject({ id: 'abc123', state: ContainerState.RUNNING });
+            expect(pubsub.publish).toHaveBeenCalledWith(PUBSUB_CHANNEL.INFO, expect.anything());
+        });
+
+        it('throws when the container cannot be found after restart', async () => {
+            mockListContainers.mockResolvedValue([]);
+            mockContainer.restart.mockResolvedValue(undefined);
+
+            await expect(service.restart('abc123')).rejects.toThrow();
+        });
+
+        it('warns and returns the container when it does not reach RUNNING state after retries', async () => {
+            mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'exited' }]);
+            mockContainer.restart.mockResolvedValue(undefined);
+
+            const result = await service.restart('abc123');
+
+            expect(result).toMatchObject({ id: 'abc123', state: ContainerState.EXITED });
+            expect(pubsub.publish).toHaveBeenCalledWith(PUBSUB_CHANNEL.INFO, expect.anything());
         });
     });
 });

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -173,6 +173,8 @@ describe('DockerService', () => {
     let service: DockerService;
 
     beforeEach(async () => {
+        (pubsub.publish as ReturnType<typeof vi.fn>).mockClear();
+
         // Reset mocks before each test
         mockListContainers.mockReset();
         mockListNetworks.mockReset();

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -38,6 +38,7 @@ const { mockDockerInstance, mockListContainers, mockGetContainer, mockListNetwor
             stop: vi.fn(),
             pause: vi.fn(),
             unpause: vi.fn(),
+            restart: vi.fn(),
             inspect: vi.fn(),
         };
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.spec.ts
@@ -403,17 +403,32 @@ describe('DockerService', () => {
         it('returns the container when it reaches RUNNING state', async () => {
             mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'running' }]);
             mockContainer.restart.mockResolvedValue(undefined);
+            mockContainer.inspect.mockResolvedValue({ State: { Status: 'running' } });
 
             const result = await service.restart('abc123');
 
             expect(mockContainer.restart).toHaveBeenCalledWith({ t: 10 });
+            expect(mockContainer.inspect).toHaveBeenCalled();
             expect(result).toMatchObject({ id: 'abc123', state: ContainerState.RUNNING });
             expect(pubsub.publish).toHaveBeenCalledWith(PUBSUB_CHANNEL.INFO, expect.anything());
+        });
+
+        it('stops polling as soon as the target state is observed', async () => {
+            mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'running' }]);
+            mockContainer.restart.mockResolvedValue(undefined);
+            mockContainer.inspect
+                .mockResolvedValueOnce({ State: { Status: 'restarting' } })
+                .mockResolvedValueOnce({ State: { Status: 'running' } });
+
+            await service.restart('abc123');
+
+            expect(mockContainer.inspect).toHaveBeenCalledTimes(2);
         });
 
         it('throws when the container cannot be found after restart', async () => {
             mockListContainers.mockResolvedValue([]);
             mockContainer.restart.mockResolvedValue(undefined);
+            mockContainer.inspect.mockResolvedValue({ State: { Status: 'running' } });
 
             await expect(service.restart('abc123')).rejects.toThrow();
         });
@@ -421,11 +436,24 @@ describe('DockerService', () => {
         it('warns and returns the container when it does not reach RUNNING state after retries', async () => {
             mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'exited' }]);
             mockContainer.restart.mockResolvedValue(undefined);
+            mockContainer.inspect.mockResolvedValue({ State: { Status: 'exited' } });
 
             const result = await service.restart('abc123');
 
             expect(result).toMatchObject({ id: 'abc123', state: ContainerState.EXITED });
             expect(pubsub.publish).toHaveBeenCalledWith(PUBSUB_CHANNEL.INFO, expect.anything());
+        });
+
+        it('tolerates inspect failures during polling', async () => {
+            mockListContainers.mockResolvedValue([{ ...containerInfo, State: 'running' }]);
+            mockContainer.restart.mockResolvedValue(undefined);
+            mockContainer.inspect
+                .mockRejectedValueOnce(new Error('temporary failure'))
+                .mockResolvedValueOnce({ State: { Status: 'running' } });
+
+            const result = await service.restart('abc123');
+
+            expect(result).toMatchObject({ id: 'abc123', state: ContainerState.RUNNING });
         });
     });
 });

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
@@ -305,7 +305,7 @@ export class DockerService {
 
         let containers: DockerContainer[];
         let updatedContainer: DockerContainer | undefined;
-        for (let i = 0; i < 5; i++) {
+        for (let i = 0; i < 20; i++) {
             await sleep(500);
             containers = await this.getContainers();
             updatedContainer = containers.find((c) => c.id === id);
@@ -319,6 +319,8 @@ export class DockerService {
 
         if (!updatedContainer) {
             throw new Error(`Container ${id} not found after restarting`);
+        } else if (updatedContainer.state !== ContainerState.RUNNING) {
+            this.logger.warn(`Container ${id} did not reach RUNNING state after restart command.`);
         }
         const appInfo = await this.getAppInfo();
         await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
@@ -199,14 +199,7 @@ export class DockerService {
     public async start(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.start();
-        const containers = await this.getContainers();
-        const updatedContainer = containers.find((c) => c.id === id);
-        if (!updatedContainer) {
-            throw new Error(`Container ${id} not found after starting`);
-        }
-        const appInfo = await this.getAppInfo();
-        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
-        return updatedContainer;
+        return this.finalizeMutation(id, 'starting');
     }
 
     public async removeContainer(id: string, options?: { withImage?: boolean }): Promise<boolean> {
@@ -248,108 +241,95 @@ export class DockerService {
     public async stop(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.stop({ t: 10 });
-
-        let containers = await this.getContainers();
-        let updatedContainer: DockerContainer | undefined;
-        for (let i = 0; i < 5; i++) {
-            await sleep(500);
-            containers = await this.getContainers();
-            updatedContainer = containers.find((c) => c.id === id);
-            this.logger.debug(
-                `Container ${id} state after stop attempt ${i + 1}: ${updatedContainer?.state}`
-            );
-            if (updatedContainer?.state === ContainerState.EXITED) {
-                break;
-            }
-        }
-
-        if (!updatedContainer) {
-            throw new Error(`Container ${id} not found after stopping`);
-        } else if (updatedContainer.state !== ContainerState.EXITED) {
+        const finalState = await this.waitForContainerState(
+            container,
+            id,
+            ContainerState.EXITED,
+            'stop',
+            5
+        );
+        if (finalState && finalState !== ContainerState.EXITED) {
             this.logger.warn(`Container ${id} did not reach EXITED state after stop command.`);
         }
-        const appInfo = await this.getAppInfo();
-        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
-        return updatedContainer;
+        return this.finalizeMutation(id, 'stopping');
     }
 
     public async pause(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.pause();
-
-        let containers: DockerContainer[];
-        let updatedContainer: DockerContainer | undefined;
-        for (let i = 0; i < 5; i++) {
-            await sleep(500);
-            containers = await this.getContainers();
-            updatedContainer = containers.find((c) => c.id === id);
-            this.logger.debug(
-                `Container ${id} state after pause attempt ${i + 1}: ${updatedContainer?.state}`
-            );
-            if (updatedContainer?.state === ContainerState.PAUSED) {
-                break;
-            }
-        }
-
-        if (!updatedContainer) {
-            throw new Error(`Container ${id} not found after pausing`);
-        }
-        const appInfo = await this.getAppInfo();
-        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
-        return updatedContainer;
+        await this.waitForContainerState(container, id, ContainerState.PAUSED, 'pause', 5);
+        return this.finalizeMutation(id, 'pausing');
     }
 
     public async restart(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.restart({ t: 10 });
-
-        let containers: DockerContainer[];
-        let updatedContainer: DockerContainer | undefined;
-        for (let i = 0; i < 20; i++) {
-            await sleep(500);
-            containers = await this.getContainers();
-            updatedContainer = containers.find((c) => c.id === id);
-            this.logger.debug(
-                `Container ${id} state after restart attempt ${i + 1}: ${updatedContainer?.state}`
-            );
-            if (updatedContainer?.state === ContainerState.RUNNING) {
-                break;
-            }
-        }
-
-        if (!updatedContainer) {
-            throw new Error(`Container ${id} not found after restarting`);
-        } else if (updatedContainer.state !== ContainerState.RUNNING) {
+        const finalState = await this.waitForContainerState(
+            container,
+            id,
+            ContainerState.RUNNING,
+            'restart',
+            20
+        );
+        if (finalState && finalState !== ContainerState.RUNNING) {
             this.logger.warn(`Container ${id} did not reach RUNNING state after restart command.`);
         }
-        const appInfo = await this.getAppInfo();
-        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
-        return updatedContainer;
+        return this.finalizeMutation(id, 'restarting');
     }
 
     public async unpause(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.unpause();
+        await this.waitForContainerState(container, id, ContainerState.RUNNING, 'unpause', 5);
+        return this.finalizeMutation(id, 'unpausing');
+    }
 
-        let containers: DockerContainer[];
-        let updatedContainer: DockerContainer | undefined;
-        for (let i = 0; i < 5; i++) {
+    /** Polls a container via `inspect()` until it reaches `targetState` or `attempts` polls have been made */
+    private async waitForContainerState(
+        container: Docker.Container,
+        id: string,
+        targetState: ContainerState,
+        operationName: string,
+        attempts: number
+    ): Promise<ContainerState | undefined> {
+        let lastState: ContainerState | undefined;
+        for (let i = 0; i < attempts; i++) {
             await sleep(500);
-            containers = await this.getContainers();
-            updatedContainer = containers.find((c) => c.id === id);
+            try {
+                const info = await container.inspect();
+                const statusStr = info.State?.Status ?? '';
+                lastState =
+                    ContainerState[statusStr.toUpperCase() as keyof typeof ContainerState] ??
+                    ContainerState.EXITED;
+            } catch (error) {
+                this.logger.debug(
+                    `Inspect failed during ${operationName} attempt ${i + 1} for ${id}: ${this.getDockerErrorMessage(error)}`
+                );
+            }
             this.logger.debug(
-                `Container ${id} state after unpause attempt ${i + 1}: ${updatedContainer?.state}`
+                `Container ${id} state after ${operationName} attempt ${i + 1}: ${lastState}`
             );
-            if (updatedContainer?.state === ContainerState.RUNNING) {
-                break;
+            if (lastState === targetState) {
+                return lastState;
             }
         }
+        return lastState;
+    }
 
+    private async finalizeMutation(id: string, operationName: string): Promise<DockerContainer> {
+        const containers = await this.getContainers();
+        const updatedContainer = containers.find((c) => c.id === id);
         if (!updatedContainer) {
-            throw new Error(`Container ${id} not found after unpausing`);
+            throw new Error(`Container ${id} not found after ${operationName}`);
         }
-        const appInfo = await this.getAppInfo();
-        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
+        await pubsub.publish(PUBSUB_CHANNEL.INFO, {
+            info: {
+                apps: {
+                    installed: containers.length,
+                    running: containers.filter((c) => c.state === ContainerState.RUNNING).length,
+                },
+            },
+        });
         return updatedContainer;
     }
 

--- a/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker.service.ts
@@ -299,6 +299,32 @@ export class DockerService {
         return updatedContainer;
     }
 
+    public async restart(id: string): Promise<DockerContainer> {
+        const container = this.client.getContainer(id);
+        await container.restart({ t: 10 });
+
+        let containers: DockerContainer[];
+        let updatedContainer: DockerContainer | undefined;
+        for (let i = 0; i < 5; i++) {
+            await sleep(500);
+            containers = await this.getContainers();
+            updatedContainer = containers.find((c) => c.id === id);
+            this.logger.debug(
+                `Container ${id} state after restart attempt ${i + 1}: ${updatedContainer?.state}`
+            );
+            if (updatedContainer?.state === ContainerState.RUNNING) {
+                break;
+            }
+        }
+
+        if (!updatedContainer) {
+            throw new Error(`Container ${id} not found after restarting`);
+        }
+        const appInfo = await this.getAppInfo();
+        await pubsub.publish(PUBSUB_CHANNEL.INFO, appInfo);
+        return updatedContainer;
+    }
+
     public async unpause(id: string): Promise<DockerContainer> {
         const container = this.client.getContainer(id);
         await container.unpause();

--- a/web/src/composables/gql/graphql.ts
+++ b/web/src/composables/gql/graphql.ts
@@ -1311,31 +1311,69 @@ export type InfoNetworkInterface = Node & {
   __typename?: 'InfoNetworkInterface';
   /** Interface description/label */
   description?: Maybe<Scalars['String']['output']>;
+  /** Link duplex mode */
+  duplex?: Maybe<Scalars['String']['output']>;
   /** IPv4 Gateway */
   gateway?: Maybe<Scalars['String']['output']>;
   id: Scalars['PrefixedID']['output'];
+  /** Whether this is an internal interface */
+  internal?: Maybe<Scalars['Boolean']['output']>;
   /** IPv4 Address */
   ipAddress?: Maybe<Scalars['String']['output']>;
+  /** IPv4 addresses assigned to this interface */
+  ipv4Addresses: Array<InfoNetworkIpv4Address>;
   /** IPv6 Address */
   ipv6Address?: Maybe<Scalars['String']['output']>;
+  /** IPv6 addresses assigned to this interface */
+  ipv6Addresses: Array<InfoNetworkIpv6Address>;
   /** IPv6 Gateway */
   ipv6Gateway?: Maybe<Scalars['String']['output']>;
   /** IPv6 Netmask */
   ipv6Netmask?: Maybe<Scalars['String']['output']>;
   /** MAC Address */
   macAddress?: Maybe<Scalars['String']['output']>;
+  /** Maximum transmission unit */
+  mtu?: Maybe<Scalars['Int']['output']>;
   /** Interface name (e.g. eth0) */
   name: Scalars['String']['output'];
   /** IPv4 Netmask */
   netmask?: Maybe<Scalars['String']['output']>;
+  /** Operational state */
+  operstate?: Maybe<Scalars['String']['output']>;
   /** IPv4 Protocol mode */
   protocol?: Maybe<Scalars['String']['output']>;
+  /** Link speed in Mbps */
+  speed?: Maybe<Scalars['Int']['output']>;
   /** Connection status */
   status?: Maybe<Scalars['String']['output']>;
+  /** Interface type */
+  type?: Maybe<Scalars['String']['output']>;
   /** Using DHCP for IPv4 */
   useDhcp?: Maybe<Scalars['Boolean']['output']>;
   /** Using DHCP for IPv6 */
   useDhcp6?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether this is a virtual interface */
+  virtual?: Maybe<Scalars['Boolean']['output']>;
+  /** VLAN identifier parsed from the interface name */
+  vlanId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** IPv4 address assigned to a network interface */
+export type InfoNetworkIpv4Address = {
+  __typename?: 'InfoNetworkIpv4Address';
+  /** IPv4 address */
+  address: Scalars['String']['output'];
+  /** IPv4 netmask */
+  netmask: Scalars['String']['output'];
+};
+
+/** IPv6 address assigned to a network interface */
+export type InfoNetworkIpv6Address = {
+  __typename?: 'InfoNetworkIpv6Address';
+  /** IPv6 address */
+  address: Scalars['String']['output'];
+  /** IPv6 prefix length */
+  prefixLength?: Maybe<Scalars['Int']['output']>;
 };
 
 export type InfoOs = Node & {
@@ -1576,6 +1614,8 @@ export type Metrics = Node & {
   id: Scalars['PrefixedID']['output'];
   /** Current memory utilization metrics */
   memory?: Maybe<MemoryUtilization>;
+  /** Current network metrics for all interfaces */
+  network: Array<NetworkMetrics>;
   /** Temperature metrics */
   temperature?: Maybe<TemperatureMetrics>;
 };
@@ -1825,6 +1865,39 @@ export type Network = Node & {
   __typename?: 'Network';
   accessUrls?: Maybe<Array<AccessUrl>>;
   id: Scalars['PrefixedID']['output'];
+};
+
+export type NetworkMetrics = Node & {
+  __typename?: 'NetworkMetrics';
+  /** Total received bytes */
+  bytesReceived: Scalars['BigInt']['output'];
+  /** Total transmitted bytes */
+  bytesSent: Scalars['BigInt']['output'];
+  id: Scalars['PrefixedID']['output'];
+  /** Metric collection timestamp */
+  lastUpdated: Scalars['DateTime']['output'];
+  /** Interface identifier */
+  name: Scalars['String']['output'];
+  /** Operational state */
+  operstate?: Maybe<Scalars['String']['output']>;
+  /** Total received packets */
+  packetsReceived: Scalars['BigInt']['output'];
+  /** Total transmitted packets */
+  packetsSent: Scalars['BigInt']['output'];
+  /** Dropped receive packets */
+  receiveDropped: Scalars['BigInt']['output'];
+  /** Receive errors */
+  receiveErrors: Scalars['BigInt']['output'];
+  /** Receive throughput in bytes per second */
+  rxSec: Scalars['Float']['output'];
+  /** Dropped transmit packets */
+  transmitDropped: Scalars['BigInt']['output'];
+  /** Transmit errors */
+  transmitErrors: Scalars['BigInt']['output'];
+  /** Transmit throughput in bytes per second */
+  txSec: Scalars['Float']['output'];
+  /** Estimated link utilization percentage */
+  utilizationPercent?: Maybe<Scalars['Float']['output']>;
 };
 
 export type Node = {
@@ -2327,6 +2400,8 @@ export type Query = {
   me: UserAccount;
   metrics: Metrics;
   network: Network;
+  /** Network interfaces */
+  networkInterfaces: Array<InfoNetworkInterface>;
   /** Get all notifications */
   notifications: Notifications;
   /** Get the full OIDC configuration (admin only) */
@@ -2736,6 +2811,7 @@ export type Subscription = {
   systemMetricsCpu: CpuUtilization;
   systemMetricsCpuTelemetry: CpuPackages;
   systemMetricsMemory: MemoryUtilization;
+  systemMetricsNetwork: Array<NetworkMetrics>;
   systemMetricsTemperature?: Maybe<TemperatureMetrics>;
   upsUpdates: UpsDevice;
 };

--- a/web/src/composables/gql/graphql.ts
+++ b/web/src/composables/gql/graphql.ts
@@ -366,6 +366,10 @@ export enum ArrayState {
 }
 
 export type ArrayStateInput = {
+  /** Optional keyfile contents used to unlock encrypted array disks when starting the array. Accepts a data URL or raw base64 payload. */
+  decryptionKeyfile?: InputMaybe<Scalars['String']['input']>;
+  /** Optional password used to unlock encrypted array disks when starting the array */
+  decryptionPassword?: InputMaybe<Scalars['String']['input']>;
   /** Array state */
   desiredState: ArrayStateInputState;
 };
@@ -948,6 +952,8 @@ export type DockerMutations = {
   pause: DockerContainer;
   /** Remove a container */
   removeContainer: Scalars['Boolean']['output'];
+  /** Restart a container */
+  restart: DockerContainer;
   /** Start a container */
   start: DockerContainer;
   /** Stop a container */
@@ -973,6 +979,11 @@ export type DockerMutationsPauseArgs = {
 export type DockerMutationsRemoveContainerArgs = {
   id: Scalars['PrefixedID']['input'];
   withImage?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type DockerMutationsRestartArgs = {
+  id: Scalars['PrefixedID']['input'];
 };
 
 


### PR DESCRIPTION
Adds a mutation to restart docker containers. 
Work Intent approved by SimonF CLD-411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restart Docker containers via the API with permission checks, automatic polling/retry to restore running state, and app status published after restart.
  * GraphQL schema updated: added restart mutation and networkInterfaces; extended container input for disk decryption fields.

* **Tests**
  * Added unit tests for the restart flow and strengthened mocks/timing control to ensure isolated, reliable behavior.

* **Chores**
  * API version bumped (dev config).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->