### PR TITLE
fix(plugin): preserve Connect during install start

### DIFF
--- a/plugin/plugins/dynamix.unraid.net.plg
+++ b/plugin/plugins/dynamix.unraid.net.plg
@@ -596,7 +596,7 @@ echo "DEBUG: Attempting to run unraid-api directly:"
 
 echo "If no additional messages appear within 30 seconds, it is safe to refresh the page."
 /etc/rc.d/rc.unraid-api plugins add unraid-api-plugin-connect -b --no-restart
-/etc/rc.d/rc.unraid-api start
+SKIP_CONNECT_PLUGIN_CHECK=true /etc/rc.d/rc.unraid-api start
 
 echo "Unraid API service started"
 echo "✅ Installation is complete, it is safe to close this window"


### PR DESCRIPTION
## Summary

Follow-up to #2025. Starts the API during `.plg` installation with `SKIP_CONNECT_PLUGIN_CHECK=true` so the first install boot does not treat Connect as stale before plugin-manager has persisted `/boot/config/plugins/dynamix.unraid.net.plg`.

## Why

While testing the #2025 preview plugin against `root@unraid.local`, I could still break the first boot after remove/reinstall:

- `api.json` contained `"plugins": ["unraid-api-plugin-connect"]`
- `unraid-api plugins list` reported Connect installed
- the first post-install API boot did not initialize `ConnectPluginModule`
- a manual API restart loaded Connect correctly

The install script already adds Connect before starting the API, but during plugin-manager installation the canonical `.plg` file may still be absent at the instant the main API process starts. The runtime stale cleanup is correct for normal starts, but not for this install-start window.

## Change

- Prefix the `.plg` install-time API start with `SKIP_CONNECT_PLUGIN_CHECK=true`.
- Normal starts and restarts remain unchanged once the `.plg` exists on disk.

## Validation

- `pnpm --filter @unraid/connect-plugin test`
- On `root@unraid.local`, reproduced the break with the #2025 preview plugin after remove/reinstall.
- Installed a patched preview `.plg` with this change under the canonical `dynamix.unraid.net.plg` filename.
- Verified first post-install boot loaded `ConnectPluginModule` without a second restart.
- Verified normal `/etc/rc.d/rc.unraid-api restart` still loaded `ConnectPluginModule`.
- Final server state: API `4.35.0+f415f324`, canonical `.plg` present, `api.json` includes `unraid-api-plugin-connect`, `unraid-api plugins list` reports Connect installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Unraid API service startup to skip Connect plugin compatibility checks, improving startup reliability during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->