### PR TITLE
fix(api): isUpdateAvailable returns null for all containers when cache has an undef entry

### DIFF
--- a/api/src/unraid-api/graph/resolvers/docker/docker-php.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-php.service.spec.ts
@@ -1,0 +1,105 @@
+import { readFile } from 'fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DockerManifestService } from '@app/unraid-api/graph/resolvers/docker/docker-manifest.service.js';
+import { DockerPhpService } from '@app/unraid-api/graph/resolvers/docker/docker-php.service.js';
+
+vi.mock('fs/promises', () => ({
+    readFile: vi.fn(),
+}));
+
+const mockReadFile = vi.mocked(readFile);
+
+const writeCache = (data: unknown) => mockReadFile.mockResolvedValue(JSON.stringify(data) as never);
+
+describe('DockerPhpService.readCachedUpdateStatus', () => {
+    let service: DockerPhpService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        service = new DockerPhpService();
+    });
+
+    it('keeps valid entries even when a sibling entry is malformed', async () => {
+        // The webgui writes null digests / status:'undef' for stopped or locally-built
+        // containers. Such an entry must not discard the valid ones (regression: U8-147).
+        writeCache({
+            'netdata/netdata:latest': {
+                local: 'sha256:aaa',
+                remote: 'sha256:bbb',
+                status: 'false',
+            },
+            'my/localbuilt:latest': { local: null, remote: 'undef', status: 'undef' },
+        });
+
+        const result = await service.readCachedUpdateStatus();
+
+        expect(result['netdata/netdata:latest']).toEqual({
+            local: 'sha256:aaa',
+            remote: 'sha256:bbb',
+            status: 'false',
+        });
+        expect(result['my/localbuilt:latest']).toEqual({
+            local: null,
+            remote: 'undef',
+            status: 'undef',
+        });
+    });
+
+    it('drops entries with the wrong shape without failing the whole file', async () => {
+        writeCache({
+            'good/image:latest': { local: 'sha256:aaa', remote: 'sha256:bbb', status: 'false' },
+            'bad/image:latest': { local: 123, remote: ['nope'] },
+        });
+
+        const result = await service.readCachedUpdateStatus();
+
+        expect(Object.keys(result)).toEqual(['good/image:latest']);
+    });
+
+    it('returns an empty object when the file is missing', async () => {
+        mockReadFile.mockRejectedValue(new Error('ENOENT'));
+        await expect(service.readCachedUpdateStatus()).resolves.toEqual({});
+    });
+});
+
+describe('DockerManifestService.isUpdateAvailableCached', () => {
+    let manifest: DockerManifestService;
+    let php: DockerPhpService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        php = new DockerPhpService();
+        manifest = new DockerManifestService(php);
+    });
+
+    it('reports an available update for a container whose cache survives a malformed sibling', async () => {
+        writeCache({
+            'netdata/netdata:latest': {
+                local: 'sha256:aaa',
+                remote: 'sha256:bbb',
+                status: 'false',
+            },
+            'my/localbuilt:latest': { local: null, remote: 'undef', status: 'undef' },
+        });
+
+        await expect(manifest.isUpdateAvailableCached('netdata/netdata')).resolves.toBe(true);
+    });
+
+    it('returns null (unknown) for an undef entry instead of poisoning others', async () => {
+        writeCache({
+            'my/localbuilt:latest': { local: null, remote: 'undef', status: 'undef' },
+        });
+
+        await expect(manifest.isUpdateAvailableCached('my/localbuilt')).resolves.toBeNull();
+    });
+
+    it('returns false when local and remote digests match', async () => {
+        writeCache({
+            'foo/bar:latest': { local: 'sha256:same', remote: 'sha256:same', status: 'true' },
+        });
+
+        await expect(manifest.isUpdateAvailableCached('foo/bar')).resolves.toBe(false);
+    });
+});

--- a/api/src/unraid-api/graph/resolvers/docker/docker-php.service.ts
+++ b/api/src/unraid-api/graph/resolvers/docker/docker-php.service.ts
@@ -15,16 +15,20 @@ type StatusItem = { name: string; updateStatus: 0 | 1 | 2 | 3 };
 /**
  * These types reflect the structure of the /var/lib/docker/unraid-update-status.json file,
  * which is not controlled by the Unraid API.
+ *
+ * The webgui (DockerClient.php) writes `local`/`remote` as null when a digest can't be
+ * resolved and `status` as the literal string 'undef' when the comparison is unknown
+ * (common for stopped or locally-built containers). The schema must tolerate those shapes,
+ * otherwise a single such entry would fail validation for the entire file.
  */
 const CachedStatusEntrySchema = z.object({
-    /** sha256 digest - "sha256:..." */
-    local: z.string(),
-    /** sha256 digest - "sha256:..." */
-    remote: z.string(),
-    /** whether update is available (true), not available (false), or unknown (null) */
-    status: z.enum(['true', 'false']).nullable(),
+    /** sha256 digest - "sha256:...", or null when unresolved */
+    local: z.string().nullable().optional(),
+    /** sha256 digest - "sha256:...", or null when unresolved */
+    remote: z.string().nullable().optional(),
+    /** 'true'/'false' when known, 'undef' or null when unknown */
+    status: z.string().nullable().optional(),
 });
-const CachedStatusSchema = z.record(z.string(), CachedStatusEntrySchema);
 export type CachedStatusEntry = z.infer<typeof CachedStatusEntrySchema>;
 
 @Injectable()
@@ -43,11 +47,22 @@ export class DockerPhpService {
     ): Promise<Record<string, CachedStatusEntry>> {
         try {
             const cache = await readFile(cacheFile, 'utf8');
-            const cacheData = JSON.parse(cache);
-            const { success, data } = CachedStatusSchema.safeParse(cacheData);
-            if (success) return data;
-            this.logger.warn(cacheData, 'Invalid cached update status');
-            return {};
+            const cacheData: unknown = JSON.parse(cache);
+            if (cacheData === null || typeof cacheData !== 'object') {
+                this.logger.warn(cacheData, 'Invalid cached update status');
+                return {};
+            }
+            // Parse per-entry so one malformed container doesn't discard the whole file.
+            const result: Record<string, CachedStatusEntry> = {};
+            for (const [image, entry] of Object.entries(cacheData)) {
+                const { success, data } = CachedStatusEntrySchema.safeParse(entry);
+                if (success) {
+                    result[image] = data;
+                } else {
+                    this.logger.warn(entry, `Skipping invalid cached update status for ${image}`);
+                }
+            }
+            return result;
         } catch (error) {
             this.logger.warn(error, 'Failed to read cached update status');
             return {};

--- a/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
@@ -487,6 +487,6 @@ describe('OidcService Integration Tests - Enhanced Logging', () => {
             expect(result.details).toHaveProperty('type');
             // Should be one of the known transport failure types
             expect(['SSL_ERROR', 'FETCH_ERROR', 'DNS_ERROR']).toContain((result.details as any).type);
-        });
+        }, 20000);
     });
 });

--- a/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
+++ b/api/src/unraid-api/graph/resolvers/sso/core/oidc.service.integration.test.ts
@@ -17,7 +17,10 @@ import { OidcProvider } from '@app/unraid-api/graph/resolvers/sso/models/oidc-pr
 import { OidcSessionService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-session.service.js';
 import { OidcStateService } from '@app/unraid-api/graph/resolvers/sso/session/oidc-state.service.js';
 
-describe('OidcService Integration Tests - Enhanced Logging', () => {
+// These integration tests make real outbound network calls (discovery, SSL/DNS
+// probes), which can exceed the 5s default under slow CI networking. Give the
+// whole suite generous headroom.
+describe('OidcService Integration Tests - Enhanced Logging', { timeout: 20000 }, () => {
     let service: OidcService;
     let configPersistence: OidcConfigPersistence;
     let loggerSpy: any;
@@ -487,6 +490,6 @@ describe('OidcService Integration Tests - Enhanced Logging', () => {
             expect(result.details).toHaveProperty('type');
             // Should be one of the known transport failure types
             expect(['SSL_ERROR', 'FETCH_ERROR', 'DNS_ERROR']).toContain((result.details as any).type);
-        }, 20000);
+        });
     });
 });


### PR DESCRIPTION
## Summary

`docker.containers[].isUpdateAvailable` resolves to `null` for **every** container, even though `containerUpdateStatuses` (a separate code path) reports the correct `UP_TO_DATE` / `UPDATE_AVAILABLE` / `UNKNOWN` values for the same containers.

## Root cause

`isUpdateAvailable` reads `/var/lib/docker/unraid-update-status.json`, which the **webgui** (`DockerClient.php`) writes — not the API. For stopped or locally-built containers the webgui legitimately writes `local`/`remote` as `null` and `status` as the string `'undef'` (surfaced elsewhere as `UNKNOWN`).

The API validated the whole file with `z.record(...)`, which fails wholesale if any single value fails. The entry schema required non-null `local`/`remote` strings and `status` of exactly `'true' | 'false'`, so a single `undef`/`null` entry rejected the entire file → `readCachedUpdateStatus()` returned `{}` → every container reported `null`, including ones that actually had updates.

This matches the report exactly: the failing response contained several `UNKNOWN` (`undef`) entries, which poisoned the parse for all rows.

## Fix

* Loosen `CachedStatusEntrySchema` to match what the webgui actually writes (`local`/`remote` nullable+optional, `status` an optional nullable string so `'undef'` is accepted).
* Parse the cache **per-entry**, keeping valid entries and skipping only malformed ones (with a warning) instead of discarding the whole file.

Downstream logic in `isUpdateAvailableCached` already handled these shapes (it filters `undef` digests and treats any non-`true`/`false` status as unknown), so it just needed to actually receive the data.

## Tests

Added `docker-php.service.spec.ts` covering the regression (a valid entry survives a malformed sibling), per-entry dropping of bad entries, and the manifest behavior. Full API suite + type-check pass.

## Links

* Linear: [CLD-732](https://linear.app/lime-technology/issue/CLD-732/docker-graphql-isupdateavailable-always-returns-null)
* FeatureOS: [https://product.unraid.net/p/docker-graphql-isupdateavailable-always-returns-null](<https://product.unraid.net/p/docker-graphql-isupdateavailable-always-returns-null>)

Fixes [CLD-732](https://linear.app/lime-technology/issue/CLD-732/docker-graphql-isupdateavailable-always-returns-null)

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Docker update status caching—malformed cache entries no longer cause the entire cache to fail, allowing valid entries to be processed normally.
* **Tests**
  * Added comprehensive test coverage for Docker cache validation edge cases.
  * Extended OIDC integration test timeout for improved reliability.