### PR TITLE
test(web): provide a default Apollo client in vitest setup

### DIFF
--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,6 +1,8 @@
 import { ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
+import { provideApolloClient } from '@vue/apollo-composable';
 
+import { ApolloClient, ApolloLink, InMemoryCache, Observable } from '@apollo/client/core';
 import { beforeEach, vi } from 'vitest';
 
 vi.mock('@vue/apollo-composable', async () => {
@@ -19,6 +21,20 @@ vi.mock('@vue/apollo-composable', async () => {
     useQuery: useQueryMock,
   };
 });
+
+// Provide a no-op default Apollo client for the whole test run. Even with
+// useQuery mocked above, some components and generated composables resolve the
+// default client asynchronously (e.g. during teardown, after the test that
+// triggered them has finished). Without a provided client, @vue/apollo-composable
+// throws "Apollo client with id default not found" as an unhandled rejection,
+// polluting unrelated suites. A terminating link that emits an empty result keeps
+// any stray operation quiet without making network calls.
+provideApolloClient(
+  new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new ApolloLink(() => Observable.of({ data: {} })),
+  })
+);
 
 // Mock WebSocket for test environment
 if (!global.WebSocket) {


### PR DESCRIPTION
Full web vitest suite emits ~22 `Apollo client with id default not found` **unhandled rejections**, attributed to unrelated files (`Modals.test.ts`, `DowngradeOs.test.ts`). They don't fail the build but add noise and risk false positives.

They appear only in the full suite (not in isolation): some components/generated composables resolve the default Apollo client *asynchronously* (during teardown, after the triggering test finished), when no client is in scope; the `useQuery` mock doesn't cover those paths.

**Fix:** provide a no-op default Apollo client in `web/vitest.setup.ts` (`InMemoryCache` + a terminating `ApolloLink` emitting an empty result) so `resolveClient` always succeeds. No network calls; `useQuery` stays mocked.

**Verification:** full web suite locally — 64 files / 641 tests pass, **zero** unhandled rejections (was 22).

Test-harness only; no runtime changes. Split out of #2033, where these were noticed (pre-existing on main, unrelated to that feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup configuration to prevent unhandled errors during test execution and ensure proper test environment initialization.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->