### PR TITLE
fix(ui): smooth notification drawer slide-in/out

### DIFF
--- a/unraid-ui/src/components/common/sheet/SheetContent.vue
+++ b/unraid-ui/src/components/common/sheet/SheetContent.vue
@@ -47,7 +47,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
 <template>
   <DialogPortal :disabled="disabled" :force-mount="forceMount" :to="teleportTarget">
     <DialogOverlay
-      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60"
+      class="data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 fixed inset-0 z-50 bg-black/60 data-[state=closed]:duration-200 data-[state=open]:duration-300"
     />
     <DialogContent :class="sheetClass" v-bind="forwarded">
       <slot />

--- a/unraid-ui/src/components/common/sheet/sheet.variants.ts
+++ b/unraid-ui/src/components/common/sheet/sheet.variants.ts
@@ -2,7 +2,12 @@ import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 
 export const sheetVariants = cva(
-  'fixed z-50 bg-background gap-4 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 border-border',
+  // Animate ONLY via the transform/opacity keyframes (animate-in/out). The panel is
+  // promoted to its own compositor layer (will-change-transform) so the slide runs
+  // off the main thread and is not stalled by the panel's contents mounting. We do
+  // NOT add a blanket `transition` here: it would transition every property
+  // (box-shadow, filter, …) alongside the keyframe and cause per-frame repaints.
+  'fixed z-50 bg-background gap-4 shadow-lg border-border will-change-transform data-[state=open]:animate-in data-[state=open]:duration-300 data-[state=open]:ease-out data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=closed]:ease-in',
   {
     variants: {
       side: {

--- a/web/src/components/Notifications/Sidebar.vue
+++ b/web/src/components/Notifications/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useMutation, useQuery, useSubscription } from '@vue/apollo-composable';
 
@@ -139,10 +139,30 @@ const readArchivedCount = computed(() => {
 const prepareToViewNotifications = () => {
   void recalculateOverview();
 };
+
+// Defer mounting the (heavy) tab/list body until the panel has started its open
+// animation. The slide is a compositor transform, but the panel's FIRST paint must
+// finish before it can show — keeping that first paint cheap (header only) lets the
+// slide start immediately instead of hitching while the notification lists mount.
+const open = ref(false);
+const bodyMounted = ref(false);
+watch(open, (isOpen) => {
+  if (isOpen) {
+    bodyMounted.value = false;
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        if (open.value) bodyMounted.value = true;
+      })
+    );
+  }
+  // On close, keep the body mounted so it stays visible during the exit slide; reka
+  // unmounts the whole SheetContent (and the body with it) once the exit animation
+  // finishes.
+});
 </script>
 
 <template>
-  <Sheet>
+  <Sheet v-model:open="open">
     <SheetTrigger as-child>
       <Button variant="header" size="header" @click="prepareToViewNotifications">
         <span class="sr-only">{{ t('notifications.sidebar.openButtonSr') }}</span>
@@ -158,6 +178,7 @@ const prepareToViewNotifications = () => {
           <SheetTitle class="text-2xl">{{ t('notifications.sidebar.title') }}</SheetTitle>
         </SheetHeader>
         <Tabs
+          v-if="bodyMounted"
           default-value="unread"
           class="flex min-h-0 flex-1 flex-col"
           :aria-label="t('notifications.sidebar.statusTabsAria')"


### PR DESCRIPTION
## Summary

Smooths the notification drawer (and every other `Sheet` / `ResponsiveModal`) open/close, which was extremely janky on mobile. The fix lives in the **design-system primitive** (`@unraid/ui` `Sheet`), not patched only in the notification consumer, so all sheets benefit.

## Diagnosis

- `sheet.variants.ts` set a blanket `transition ease-in-out` that ran **alongside** reka's enter/exit keyframes — so every property (`box-shadow`, `filter`, `transform`) transitioned each frame, and the panel was never promoted to its own compositor layer.
- Durations were long and asymmetric (500ms open / 300ms close) with no `will-change` hint.
- Opening the notification drawer mounted the full body — `Tabs` + two Apollo-backed `NotificationsList`s — **synchronously**, stalling the slide's first frames.

Not the cause (ruled out): it was already animating `translate3d` (not `width`/`left`), and `Sheet.vue`'s viewport-meta rewrite is benign (the live webgui viewport is already `width=device-width, initial-scale=1`, so it only toggles zoom-lock — no reflow).

## Changes

- **`sheet.variants.ts`** — drop the blanket `transition`; animate only via the transform/opacity keyframes; add `will-change-transform` (compositor promotion); snappy symmetric timing (300ms open / 200ms close, `ease-out` / `ease-in`).
- **`SheetContent.vue`** — match the overlay fade duration to the panel (300/200ms).
- **`Notifications/Sidebar.vue`** — bind `v-model:open` and defer mounting the tab/list body ~2 frames after open (cheap first paint → slide starts immediately); the body stays mounted through the exit slide, and reka unmounts it with the panel.

## Design system

The change is in the `@unraid/ui` `Sheet` primitive (design system), so it fixes the animation for all consumers (`ResponsiveModal` included). The existing `Sheet.stories.ts` renders the improved animation automatically and asserts nothing about timing, so no story changes are needed. `pnpm --filter @unraid/ui build` is clean.

## Testing
Deployed to a 7.3.2 dev server; open/close the notification bell — the slide is smooth and no longer hitches on mount.
