### PR TITLE
fix(ci): resolve PR number for fork PR plugin uploads

### DIFF
--- a/.github/workflows/upload-pr-plugin.yml
+++ b/.github/workflows/upload-pr-plugin.yml
@@ -33,13 +33,30 @@ jobs:
           script: |
             const workflowRun = context.payload.workflow_run;
             const runId = workflowRun.id;
+            const headSha = workflowRun.head_sha;
+
+            // Same-repo PRs populate this directly.
             let prNumber = workflowRun.pull_requests?.[0]?.number;
 
+            // Fork PRs leave pull_requests empty. Match the run's head commit
+            // against open PRs; pr.head.sha is the fork commit, so this works
+            // across repositories where the commits API cannot.
+            if (!prNumber) {
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              prNumber = pulls.find((pr) => pr.head.sha === headSha)?.number;
+            }
+
+            // Last resort: only finds same-repo commits.
             if (!prNumber) {
               const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                commit_sha: workflowRun.head_sha,
+                commit_sha: headSha,
               });
               prNumber = prs.data[0]?.number;
             }


### PR DESCRIPTION
Fixes CLD-727 — https://linear.app/lime-technology/issue/CLD-727

## Summary

The `upload-pr-plugin.yml` `workflow_run` job — the fork-safe path that publishes the PR preview plugin to Cloudflare — fails at its first step, **"Resolve workflow run context"**, for any PR opened from a fork/clone. Same-repo PRs are unaffected.

Confirmed against real failed runs (e.g. run `28615830670`): only that step failed; every downstream step was skipped.

## Root cause

- GitHub leaves `workflow_run.pull_requests` **empty** for fork-originated runs.
- The existing fallback `listPullRequestsAssociatedWithCommit` also returns nothing, because the head commit lives in the **fork**, not `unraid/api`.
- So the step hits `core.setFailed('Unable to resolve a pull request…')`.

Same-repo PRs populate `pull_requests` directly, which is why they work and forks don't.

## Fix

Add a middle resolution step: when `pull_requests` is empty, list open PRs on the base repo and match `pr.head.sha === workflow_run.head_sha`. `pr.head.sha` is the fork's commit SHA, so this resolves cross-repo where the commits API can't. The commits-API call is kept as a last resort.

Everything downstream already works for forks — the CI artifact lives on the base repo's run, and the `workflow_run` job carries the base repo's secrets and `pull-requests: write` token — so this single step was the only blocker.

## Testing

Validated the workflow YAML parses. End-to-end behavior only runs in GitHub Actions on a real fork PR; verifiable on the next fork PR.