### PR TITLE
style(notifications): smoother dismiss/archive animation

### DIFF
--- a/web/src/components/Notifications/List.vue
+++ b/web/src/components/Notifications/List.vue
@@ -106,6 +106,53 @@ const importanceLabel = computed(() => {
   }
 });
 
+// Dismiss/leave animation: the card slides out to the right while collapsing its
+// own vertical space (height + margins + padding + borders), so the cards below
+// flow up as a single continuous motion instead of jumping after the fact.
+const prefersReducedMotion =
+  typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+function onLeave(el: Element, done: () => void) {
+  if (prefersReducedMotion || !(el instanceof HTMLElement)) {
+    done();
+    return;
+  }
+  const node = el;
+  const cs = getComputedStyle(node);
+  node.style.overflow = 'hidden';
+  node.style.boxSizing = 'border-box';
+  const animation = node.animate(
+    [
+      {
+        opacity: 1,
+        transform: 'translateX(0)',
+        height: `${node.offsetHeight}px`,
+        marginTop: cs.marginTop,
+        marginBottom: cs.marginBottom,
+        paddingTop: cs.paddingTop,
+        paddingBottom: cs.paddingBottom,
+        borderTopWidth: cs.borderTopWidth,
+        borderBottomWidth: cs.borderBottomWidth,
+      },
+      { opacity: 0, transform: 'translateX(2rem)', offset: 0.55 },
+      {
+        opacity: 0,
+        transform: 'translateX(2rem)',
+        height: '0px',
+        marginTop: '0px',
+        marginBottom: '0px',
+        paddingTop: '0px',
+        paddingBottom: '0px',
+        borderTopWidth: '0px',
+        borderBottomWidth: '0px',
+      },
+    ],
+    { duration: 340, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' }
+  );
+  animation.onfinish = done;
+  animation.oncancel = done;
+}
+
 const noNotificationsMessage = computed(() => {
   if (!props.importance) {
     return t('notifications.list.noNotifications');
@@ -122,16 +169,7 @@ const noNotificationsMessage = computed(() => {
     v-infinite-scroll="[onLoadMore, { canLoadMore: () => canLoadMore }]"
     class="flex min-h-0 flex-1 flex-col overflow-y-scroll px-3"
   >
-    <TransitionGroup
-      name="notification-list"
-      tag="div"
-      class="divide-y"
-      enter-active-class="transition-all duration-300 ease-out"
-      leave-active-class="transition-all duration-300 ease-in absolute right-0 left-0"
-      enter-from-class="opacity-0 -translate-x-4"
-      leave-to-class="opacity-0 translate-x-4"
-      move-class="transition-transform duration-300"
-    >
+    <TransitionGroup name="notification-list" tag="div" class="divide-y" @leave="onLeave">
       <NotificationsItem
         v-for="notification in notifications"
         :key="notification.id"
@@ -153,3 +191,27 @@ const noNotificationsMessage = computed(() => {
     </div>
   </LoadingError>
 </template>
+
+<style scoped>
+/* New items ease in; reorders (e.g. a persistent item moving to the top) glide via
+   FLIP. The dismiss/leave animation is handled in JS (onLeave) so the card can
+   slide out AND collapse its own space in one continuous motion. */
+.notification-list-move,
+.notification-list-enter-active {
+  transition:
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.notification-list-enter-from {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notification-list-move,
+  .notification-list-enter-active {
+    transition: none;
+  }
+}
+</style>


### PR DESCRIPTION
## What

Extracts **just the notification dismiss/archive animation improvement** from the larger `feat/persistent-notifications` branch into a standalone change off `main`.

Replaces the old janky leave animation on the notifications list — where a dismissed card snapped to full width via `position: absolute`, slid out, and left a gap that jumped closed — with a Web Animations API `@leave` hook. The card now slides right while collapsing its own height, margins, padding, and borders in one continuous motion, so the rows below flow up smoothly.

## Details

- **JS-driven leave** (`onLeave`): drives height + spacing collapse alongside the slide/fade so siblings glide up instead of jumping after the fact.
- **Enter + reorder** stay CSS-driven via `<style scoped>` FLIP `move`/`enter` transitions.
- Honors `prefers-reduced-motion` (both the JS leave and the CSS transitions no-op).

Only `web/src/components/Notifications/List.vue` changes — no backend or feature work from the source branch is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added smoother notification dismissal animations, including a slide-out and space-collapse effect.
  * Improved accessibility by respecting users’ reduced-motion preferences.
  * Preserved notification list movement and entry transitions for a more polished experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->