### PR TITLE
fix(ci): publish PR plugin after unrelated failures

### DIFF
--- a/.github/workflows/upload-pr-plugin.yml
+++ b/.github/workflows/upload-pr-plugin.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   upload-pr-plugin:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -76,6 +76,7 @@ jobs:
           mkdir -p "${{ runner.temp }}/pr-plugin"
 
       - name: Download plugin artifact
+        id: artifact
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           RUN_ID: ${{ steps.context.outputs.run_id }}
@@ -96,7 +97,8 @@ jobs:
             );
 
             if (!artifact) {
-              core.setFailed(`No unraid-plugin artifact found for workflow run ${runId}`);
+              core.notice(`No unraid-plugin artifact found for workflow run ${runId}; skipping upload`);
+              core.setOutput('found', 'false');
               return;
             }
 
@@ -109,9 +111,11 @@ jobs:
 
             const zipPath = path.join(process.env.RUNNER_TEMP, 'pr-plugin', 'artifact.zip');
             fs.writeFileSync(zipPath, Buffer.from(download.data));
+            core.setOutput('found', 'true');
             core.info(`Downloaded ${artifact.name}`);
 
       - name: Extract and validate plugin files
+        if: steps.artifact.outputs.found == 'true'
         id: files
         run: |
           set -Eeuo pipefail
@@ -171,6 +175,7 @@ jobs:
           ls -la "$DEPLOY_DIR"
 
       - name: Upload plugin to Cloudflare
+        if: steps.artifact.outputs.found == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_SECRET_ACCESS_KEY }}
@@ -199,6 +204,7 @@ jobs:
             --acl public-read
 
       - name: Comment URL
+        if: steps.artifact.outputs.found == 'true'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
         with:
           number: ${{ steps.context.outputs.pr_number }}


### PR DESCRIPTION
## Summary
PR plugin previews were not published when any unrelated CI job failed; this changes the upload workflow to publish whenever the upstream PR run produced a plugin artifact.

## Why This Exists
The PR 2044 plugin built successfully, but an Audit Dependencies failure made the aggregate workflow conclusion fail. The upload workflow required an overall success conclusion, so it skipped and left the advertised preview URL returning 404.

## Resolution
Run the uploader for every completed pull-request workflow and use the plugin artifact itself as the gate. If the artifact exists, publication proceeds even when another job failed. If no artifact exists, the workflow records a notice and cleanly skips extraction, upload, and commenting.

## Reviewer Considerations
- Confirm artifact presence is the correct boundary for publishing a test-only PR preview.
- Upload validation, Cloudflare credentials, and file checks remain unchanged.
- This does not weaken merge protection or alter the status of unrelated CI failures.

## Behavior Changes
A successfully built PR plugin is uploaded to the preview bucket even when another job in the upstream workflow fails. PR runs without a plugin artifact do not attempt an upload.

## Implementation Summary
- Removed aggregate workflow success from the uploader job condition.
- Added an explicit artifact-found output.
- Conditioned extraction, Cloudflare upload, and PR commenting on that output.

## Verification
- `git diff --check` passed.
- `actionlint .github/workflows/upload-pr-plugin.yml` passed.
- The repository pre-commit hook could not run because `lint-staged` is not installed in this isolated worktree; the workflow-specific validations above passed.

## Risk
Low; the change only broadens preview publication to already-produced artifacts and retains all existing artifact and file validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation workflows to gracefully handle missing plugin artifacts.
  * Prevented unnecessary upload attempts and pull request comments when no plugin artifact is available.
  * Workflows now continue without failure when the expected artifact is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->