### PR TITLE
fix(header): preserve version dropdown hover contrast

### DIFF
--- a/web/src/components/Header/HeaderVersion.vue
+++ b/web/src/components/Header/HeaderVersion.vue
@@ -166,7 +166,7 @@ const updateOsStatus = computed(() => {
 
         <DropdownMenuItem
           :disabled="!displayOsVersion"
-          class="cursor-pointer text-xs hover:bg-gray-100 dark:hover:bg-gray-800"
+          class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground cursor-pointer text-xs"
           @click="copyOsVersion"
         >
           <span class="flex w-full items-center justify-between">
@@ -180,7 +180,7 @@ const updateOsStatus = computed(() => {
 
         <DropdownMenuItem
           :disabled="!apiVersion"
-          class="cursor-pointer text-xs hover:bg-gray-100 dark:hover:bg-gray-800"
+          class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground cursor-pointer text-xs"
           @click="copyApiVersion"
         >
           <span class="flex w-full items-center justify-between">


### PR DESCRIPTION
## Summary
Version dropdown rows now apply matching semantic foreground and background colors on hover and keyboard focus, preserving readable contrast in White and Azure themes.

## Why This Exists
The version dropdown used theme-specific hover backgrounds without explicitly setting the corresponding foreground color. In light themes, that could leave hovered text unreadable.

## Resolution
Use the shared accent and accent-foreground semantic tokens for both hovered and focused version rows. This keeps the interaction state aligned with the active theme rather than relying on gray color utilities.

## Reviewer Considerations
- The change is deliberately scoped to the two copyable version rows; it does not alter the shared dropdown primitive or unrelated menus.
- Hover and keyboard-focus states receive the same token pair for consistent pointer and keyboard contrast.

## Behavior Changes
- Hovered or focused Unraid OS and API version rows remain legible in White and Azure themes.

## Implementation Summary
- Replace fixed gray hover backgrounds with semantic accent background and foreground utility classes in the header version dropdown.

## Verification
- `pnpm --dir web run pretest` (passed; UI build completed with pre-existing TypeScript diagnostics in `Accordion.vue`)
- `pnpm --dir web exec vitest run __test__/components/HeaderOsVersion.test.ts` (3 passed)
- `pnpm --dir web exec eslint src/components/Header/HeaderVersion.vue` (passed)
- `pnpm --dir web exec prettier --check src/components/Header/HeaderVersion.vue` (passed)
- `git diff --check` (passed)

## Risk
Low; the change only applies established semantic colors to existing interaction states.