### PR TITLE
fix(ci): make dependency audit non-blocking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,9 @@ jobs:
   audit:
     name: Audit Dependencies
     runs-on: ubuntu-latest
+    # Advisory-only: surface vulnerable dependencies without failing the
+    # workflow, so an audit finding can never block a release or publish.
+    continue-on-error: true
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
The `Audit Dependencies` job (`pnpm run audit --prod`) fails the entire **CI - Main (API)** workflow whenever a transitive production dependency has an open advisory. This turned the [4.36.0 release run](https://github.com/unraid/api/actions/runs/29869430785) red over unrelated advisories (`hono`, `fast-uri`, `immutable`) and required manual recovery of the production publish. This change marks the audit job `continue-on-error` so it can never block a release again.

## Why This Exists
`audit` is not in any publish job's `needs`, so it doesn't gate publishing through the dependency graph — it blocks by turning the **aggregate workflow conclusion** red, which branch protection, downstream `workflow_run` gates, and humans all key off of. This is the same class of failure already patched for PR plugin previews in #2046, whose commit note reads: *"an Audit Dependencies failure made the aggregate workflow conclusion fail."* Rather than papering over the three current advisories in the ignore list, this keeps the audit fully decoupled from the publish path.

## Resolution
Add `continue-on-error: true` to the `audit` job. The audit still runs on every PR and push and still surfaces vulnerable dependencies as step annotations and logs, but a finding no longer fails the workflow.

## Behavior Changes
- A dependency advisory no longer fails **CI - Main (API)** or blocks a release/publish.
- The `Audit Dependencies` job now reports success (with the failing step annotated) even when advisories are present.

## Trade-off
The audit becomes advisory-only: a genuinely high/critical advisory will also no longer block a release. Individual advisories can still be triaged/suppressed via the existing `pnpm.auditConfig` (`ignoreCves` / `ignoreGhsas`) mechanism in `package.json` if a hard gate on specific CVEs is ever wanted.

## Verification
- `actionlint .github/workflows/main.yml` reports only pre-existing shellcheck/type notes in untouched jobs; no new issues from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency audit checks are now advisory and will no longer block the workflow when issues are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->