### PR TITLE
fix(web): await automatic license key installation

### DIFF
--- a/web/__test__/components/CallbackFeedback.test.ts
+++ b/web/__test__/components/CallbackFeedback.test.ts
@@ -294,18 +294,22 @@ describe('CallbackFeedback.vue', () => {
     expect(wrapper.text()).toContain('Fix Error');
   });
 
-  it('renders the generic error state for failed key installs', () => {
+  it('renders manual-install recovery for failed key installs', () => {
     callbackStatus.value = 'error';
-    keyActionType.value = 'purchase';
+    keyActionType.value = 'trialStart';
     keyInstallStatus.value = 'failed';
-    keyType.value = 'Pro';
-    keyUrl.value = 'https://example.com/pro.key';
+    keyType.value = 'Trial';
+    keyUrl.value = 'https://keys.lime-technology.com/Trial.key';
 
     const wrapper = mountComponent();
 
     expect(wrapper.find('h1').text()).toBe('Error');
     expect(wrapper.find('.description').text()).toBe('Something went wrong');
-    expect(wrapper.text()).toContain('Failed to Install Pro Key');
+    expect(wrapper.text()).toContain('Failed to Install Trial Key');
+    expect(wrapper.get('.brand-button').text()).toBe('Copy Key URL');
+    expect(wrapper.get('a[href="/Tools/Registration"]').text()).toBe(
+      'Then go to Tools > Registration to manually install it'
+    );
     expect(wrapper.find('.modal').attributes('data-error')).toBe('true');
     expect(wrapper.find('.modal').attributes('data-success')).toBe('false');
   });

--- a/web/__test__/store/installKey.test.ts
+++ b/web/__test__/store/installKey.test.ts
@@ -113,6 +113,33 @@ describe('InstallKey Store', () => {
       expect(store.keyType).toBe('license');
     });
 
+    it.each([
+      {
+        name: 'Unraid 6.12.15/7.0 stopped-array response',
+        response: { status: 'Please Stop array to complete key installation' },
+      },
+      {
+        name: 'Unraid 6.12.15/7.0 stopped response',
+        response: { status: '' },
+      },
+      {
+        name: 'Unraid 7.1.4 stopped response',
+        response: { status: 'success' },
+      },
+    ])('should accept the $name', async ({ response }) => {
+      mockJsonFn.mockResolvedValueOnce(response);
+
+      await store.install(
+        createTestAction({
+          type: 'purchase',
+          keyUrl: 'https://example.com/license.key',
+        })
+      );
+
+      expect(store.keyInstallStatus).toBe('success');
+      expect(mockSetError).not.toHaveBeenCalled();
+    });
+
     it('should install trialStart keys using the same install flow', async () => {
       mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
       const action = createTestAction({
@@ -221,8 +248,15 @@ describe('InstallKey Store', () => {
       });
     });
 
-    it('should reject an invalid success response', async () => {
-      mockJsonFn.mockResolvedValueOnce({ success: true });
+    it.each([
+      { name: 'response without a string status', response: { success: true } },
+      { name: 'array response', response: [{ status: 'success' }] },
+      {
+        name: 'response with a non-string optional message',
+        response: { status: 'success', message: null },
+      },
+    ])('should reject a $name', async ({ response }) => {
+      mockJsonFn.mockResolvedValueOnce(response);
 
       await store.install(
         createTestAction({
@@ -235,6 +269,26 @@ describe('InstallKey Store', () => {
       expect(mockSetError).toHaveBeenCalledWith({
         heading: 'Failed to install key',
         message: 'Invalid response from InstallKey.php',
+        level: 'error',
+        ref: 'installKey',
+        type: 'installKey',
+      });
+    });
+
+    it('should reject a resolved response containing an error', async () => {
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', error: 'download error 8' });
+
+      await store.install(
+        createTestAction({
+          type: 'purchase',
+          keyUrl: 'https://example.com/license.key',
+        })
+      );
+
+      expect(store.keyInstallStatus).toBe('failed');
+      expect(mockSetError).toHaveBeenCalledWith({
+        heading: 'Failed to install key',
+        message: 'download error 8',
         level: 'error',
         ref: 'installKey',
         type: 'installKey',

--- a/web/__test__/store/installKey.test.ts
+++ b/web/__test__/store/installKey.test.ts
@@ -10,7 +10,13 @@ import type { ExternalKeyActions } from '@unraid/shared-callbacks';
 
 import { useInstallKeyStore } from '~/store/installKey';
 
-const mockGetFn = vi.fn();
+const mockJsonFn = vi.fn();
+const mockResponseChain = {
+  error: vi.fn(),
+  json: mockJsonFn,
+};
+mockResponseChain.error.mockReturnValue(mockResponseChain);
+const mockGetFn = vi.fn(() => mockResponseChain);
 vi.mock('~/composables/services/webgui', () => ({
   WebguiInstallKey: {
     query: vi.fn(() => ({
@@ -73,7 +79,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should set status to installing when install is called', async () => {
-      mockGetFn.mockResolvedValueOnce({ success: true });
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
 
       const promise = store.install(
         createTestAction({
@@ -88,7 +94,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should handle successful install and update state', async () => {
-      mockGetFn.mockResolvedValueOnce({ success: true });
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
       const action = createTestAction({
         type: 'purchase',
         keyUrl: 'https://example.com/license.key',
@@ -100,6 +106,7 @@ describe('InstallKey Store', () => {
 
       expect(WebguiInstallKey.query).toHaveBeenCalledWith({ url: action.keyUrl });
       expect(mockGetFn).toHaveBeenCalled();
+      expect(mockJsonFn).toHaveBeenCalled();
       expect(store.keyInstallStatus).toBe('success');
       expect(store.keyActionType).toBe('purchase');
       expect(store.keyUrl).toBe('https://example.com/license.key');
@@ -107,7 +114,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should install trialStart keys using the same install flow', async () => {
-      mockGetFn.mockResolvedValueOnce({ success: true });
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
       const action = createTestAction({
         type: 'trialStart',
         keyUrl: 'https://example.com/trial.key',
@@ -119,6 +126,7 @@ describe('InstallKey Store', () => {
 
       expect(WebguiInstallKey.query).toHaveBeenCalledWith({ url: action.keyUrl });
       expect(mockGetFn).toHaveBeenCalled();
+      expect(mockJsonFn).toHaveBeenCalled();
       expect(store.keyInstallStatus).toBe('success');
       expect(store.keyActionType).toBe('trialStart');
       expect(store.keyUrl).toBe('https://example.com/trial.key');
@@ -126,7 +134,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should extract key type from .key URL', async () => {
-      mockGetFn.mockResolvedValueOnce({ success: true });
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
 
       await store.install(
         createTestAction({
@@ -139,7 +147,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should extract key type from .unkey URL', async () => {
-      mockGetFn.mockResolvedValueOnce({ success: true });
+      mockJsonFn.mockResolvedValueOnce({ status: 'success', message: 'Key installed' });
 
       await store.install(
         createTestAction({
@@ -154,7 +162,7 @@ describe('InstallKey Store', () => {
 
   describe('Error Handling', () => {
     it('should handle string errors during installation', async () => {
-      mockGetFn.mockRejectedValueOnce('error message');
+      mockJsonFn.mockRejectedValueOnce('error message');
 
       await store.install(
         createTestAction({
@@ -174,7 +182,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should handle Error object during installation', async () => {
-      mockGetFn.mockRejectedValueOnce(new Error('Test error message'));
+      mockJsonFn.mockRejectedValueOnce(new Error('Test error message'));
 
       await store.install(
         createTestAction({
@@ -194,7 +202,7 @@ describe('InstallKey Store', () => {
     });
 
     it('should handle unknown error types during installation', async () => {
-      mockGetFn.mockRejectedValueOnce({ something: 'wrong' });
+      mockJsonFn.mockRejectedValueOnce({ something: 'wrong' });
 
       await store.install(
         createTestAction({
@@ -207,6 +215,26 @@ describe('InstallKey Store', () => {
       expect(mockSetError).toHaveBeenCalledWith({
         heading: 'Failed to install key',
         message: 'Unknown error',
+        level: 'error',
+        ref: 'installKey',
+        type: 'installKey',
+      });
+    });
+
+    it('should reject an invalid success response', async () => {
+      mockJsonFn.mockResolvedValueOnce({ success: true });
+
+      await store.install(
+        createTestAction({
+          type: 'purchase',
+          keyUrl: 'https://example.com/license.key',
+        })
+      );
+
+      expect(store.keyInstallStatus).toBe('failed');
+      expect(mockSetError).toHaveBeenCalledWith({
+        heading: 'Failed to install key',
+        message: 'Invalid response from InstallKey.php',
         level: 'error',
         ref: 'installKey',
         type: 'installKey',

--- a/web/__test__/store/installKey.wretch.test.ts
+++ b/web/__test__/store/installKey.wretch.test.ts
@@ -1,0 +1,129 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ExternalKeyActions } from '@unraid/shared-callbacks';
+
+import { resolveCallbackStatus } from '~/store/callbackActions.helpers';
+import { useErrorsStore } from '~/store/errors';
+import { useInstallKeyStore } from '~/store/installKey';
+
+const action: ExternalKeyActions = {
+  type: 'trialStart',
+  keyUrl: 'https://keys.lime-technology.com/Trial.key',
+};
+
+const jsonResponse = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const createFetchController = () => {
+  let resolveFetch: (response: Response) => void = () => {
+    throw new Error('Fetch controller resolved before initialization');
+  };
+  let rejectFetch: (error: unknown) => void = () => {
+    throw new Error('Fetch controller rejected before initialization');
+  };
+  const response = new Promise<Response>((resolve, reject) => {
+    resolveFetch = resolve;
+    rejectFetch = reject;
+  });
+
+  return {
+    reject: rejectFetch,
+    resolve: resolveFetch,
+    response,
+  };
+};
+
+const flushUnhandledRejections = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('InstallKey Store with real Wretch response chains', () => {
+  const unhandledRejection = vi.fn();
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    globalThis.csrf_token = '';
+    process.on('unhandledRejection', unhandledRejection);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', unhandledRejection);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    unhandledRejection.mockClear();
+  });
+
+  const startInstall = () => {
+    const fetchController = createFetchController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => fetchController.response)
+    );
+    const store = useInstallKeyStore();
+    const installPromise = store.install(action);
+
+    return { fetchController, installPromise, store };
+  };
+
+  it('stays installing until a delayed successful response is consumed', async () => {
+    const { fetchController, installPromise, store } = startInstall();
+
+    expect(store.keyInstallStatus).toBe('installing');
+    await Promise.resolve();
+    expect(store.keyInstallStatus).toBe('installing');
+
+    fetchController.resolve(jsonResponse({ status: 'success', message: 'Key installed' }, 200));
+    await installPromise;
+    await flushUnhandledRejections();
+
+    expect(store.keyInstallStatus).toBe('success');
+    expect(unhandledRejection).not.toHaveBeenCalled();
+  });
+
+  it('turns a delayed HTTP 406 into callback error and preserves its safe message', async () => {
+    const { fetchController, installPromise, store } = startInstall();
+
+    expect(store.keyInstallStatus).toBe('installing');
+    fetchController.resolve(jsonResponse({ error: 'download error 8' }, 406));
+    await installPromise;
+    await flushUnhandledRejections();
+
+    expect(store.keyInstallStatus).toBe('failed');
+    expect(store.keyUrl).toBe(action.keyUrl);
+    expect(useErrorsStore().errors.at(-1)?.message).toBe('download error 8');
+    expect(
+      resolveCallbackStatus({
+        actions: [action],
+        accountActionStatus: 'ready',
+        keyInstallStatus: store.keyInstallStatus,
+      })
+    ).toBe('error');
+    expect(unhandledRejection).not.toHaveBeenCalled();
+  });
+
+  it('turns a delayed network rejection into callback error', async () => {
+    const { fetchController, installPromise, store } = startInstall();
+
+    expect(store.keyInstallStatus).toBe('installing');
+    fetchController.reject(new TypeError('Failed to fetch'));
+    await installPromise;
+    await flushUnhandledRejections();
+
+    expect(store.keyInstallStatus).toBe('failed');
+    expect(store.keyUrl).toBe(action.keyUrl);
+    expect(useErrorsStore().errors.at(-1)?.message).toBe('Failed to fetch');
+    expect(
+      resolveCallbackStatus({
+        actions: [action],
+        accountActionStatus: 'ready',
+        keyInstallStatus: store.keyInstallStatus,
+      })
+    ).toBe('error');
+    expect(unhandledRejection).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/store/installKey.ts
+++ b/web/src/store/installKey.ts
@@ -6,6 +6,58 @@ import type { ExternalKeyActions } from '@unraid/shared-callbacks';
 import { WebguiInstallKey } from '~/composables/services/webgui';
 import { useErrorsStore } from '~/store/errors';
 
+interface InstallKeySuccessResponse {
+  message: string;
+  status: 'success';
+}
+
+interface InstallKeyErrorResponse {
+  error: string;
+}
+
+const isInstallKeySuccessResponse = (response: unknown): response is InstallKeySuccessResponse =>
+  typeof response === 'object' &&
+  response !== null &&
+  'message' in response &&
+  typeof response.message === 'string' &&
+  'status' in response &&
+  response.status === 'success';
+
+const isInstallKeyErrorResponse = (response: unknown): response is InstallKeyErrorResponse =>
+  typeof response === 'object' &&
+  response !== null &&
+  'error' in response &&
+  typeof response.error === 'string';
+
+const parseInstallKeyErrorMessage = (message: string): string | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(message);
+    return isInstallKeyErrorResponse(parsed) ? parsed.error : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getInstallKeyErrorMessage = (error: unknown): string => {
+  if (typeof error === 'object' && error !== null && 'json' in error) {
+    const errorJson = error.json;
+    if (isInstallKeyErrorResponse(errorJson)) {
+      return errorJson.error;
+    }
+  }
+  if (typeof error === 'string') {
+    return parseInstallKeyErrorMessage(error) ?? error.toUpperCase();
+  }
+  if (error instanceof Error) {
+    return parseInstallKeyErrorMessage(error.message) ?? error.message;
+  }
+  return 'Unknown error';
+};
+
+const rethrowInstallRequestError = (error: unknown): never => {
+  throw error;
+};
+
 export const useInstallKeyStore = defineStore('installKey', () => {
   const errorsStore = useErrorsStore();
 
@@ -36,22 +88,27 @@ export const useInstallKeyStore = defineStore('installKey', () => {
     }
 
     try {
-      const installResponse = await WebguiInstallKey.query({ url: keyUrl.value }).get();
+      const installResponse: unknown = await WebguiInstallKey.query({ url: keyUrl.value })
+        .get()
+        .error('Error', rethrowInstallRequestError)
+        .error('TypeError', rethrowInstallRequestError)
+        .json();
       console.log('[install] WebguiInstallKey installResponse', installResponse);
+
+      if (!isInstallKeySuccessResponse(installResponse)) {
+        const errorMessage = isInstallKeyErrorResponse(installResponse)
+          ? installResponse.error
+          : 'Invalid response from InstallKey.php';
+        throw new Error(errorMessage);
+      }
 
       keyInstallStatus.value = 'success';
     } catch (error) {
       console.error('[install] WebguiInstallKey error', error);
-      let errorMessage = 'Unknown error';
-      if (typeof error === 'string') {
-        errorMessage = error.toUpperCase();
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
       keyInstallStatus.value = 'failed';
       errorsStore.setError({
         heading: 'Failed to install key',
-        message: errorMessage,
+        message: getInstallKeyErrorMessage(error),
         level: 'error',
         ref: 'installKey',
         type: 'installKey',

--- a/web/src/store/installKey.ts
+++ b/web/src/store/installKey.ts
@@ -7,8 +7,8 @@ import { WebguiInstallKey } from '~/composables/services/webgui';
 import { useErrorsStore } from '~/store/errors';
 
 interface InstallKeySuccessResponse {
-  message: string;
-  status: 'success';
+  message?: string;
+  status: string;
 }
 
 interface InstallKeyErrorResponse {
@@ -18,10 +18,11 @@ interface InstallKeyErrorResponse {
 const isInstallKeySuccessResponse = (response: unknown): response is InstallKeySuccessResponse =>
   typeof response === 'object' &&
   response !== null &&
-  'message' in response &&
-  typeof response.message === 'string' &&
+  !Array.isArray(response) &&
   'status' in response &&
-  response.status === 'success';
+  typeof response.status === 'string' &&
+  (!('message' in response) || typeof response.message === 'string') &&
+  !('error' in response);
 
 const isInstallKeyErrorResponse = (response: unknown): response is InstallKeyErrorResponse =>
   typeof response === 'object' &&


### PR DESCRIPTION
## Summary

Automatic license-key installation could report success before WebGUI answered; this waits for the response, routes failures into the existing manual recovery flow, and accepts successful response bodies from every supported Unraid release.

## Why This Exists

Wretch 2.11.0 starts the request when `.get()` is called but returns a non-thenable response chain. Awaiting that chain without consuming it completed immediately, allowing the store to set `keyInstallStatus` to `success` while the HTTP request was still pending.

A later WebGUI 406 response, including a download failure, or a fetch rejection then became an unhandled background rejection. The callback stayed successful and users did not see the existing Copy Key URL and Tools > Registration recovery instructions.

The initial fix also validated only `{ status: "success", message: string }`. That shape is produced by Unraid 7.2+, but supported older WebGUI releases return `{ status: "" }`, a localized instruction in `status`, or `{ status: "success" }` without a message. Rejecting those responses could report failure after the key had already been written.

## Resolution

Consume the Wretch response with `.json()` and locally rethrow shared request errors into the install store catch path. Treat a 2xx JSON body as successful only when it is a non-array object with a string `status`, an optional string `message`, and no `error` member.

This preserves the historical WebGUI success contract without weakening failure handling. The existing trial action and key URL remain intact, and the change does not retry or reissue a license.

## Reviewer Considerations

- Confirm the response contract against WebGUI history: 6.12.15 and 7.0 use string status text, 7.1.4 may omit `message`, and 7.2+ returns both fields.
- Review the per-call `Error` and `TypeError` rethrow handlers. The shared request resolver otherwise consumes those failures after recording them, while this store owns the installation lifecycle state.
- A resolved 2xx body containing an `error` member is rejected and preserves the safe error string.
- The related unused `WebguiNotify` helper has the same unconsumed response-chain pattern but remains outside this PR because no repository callers were found.

## Behavior Changes

- A delayed successful install remains `installing` until WebGUI responds, then becomes `success`.
- Successful WebGUI responses from supported Unraid 6.12.15 through current releases are accepted.
- HTTP 406, resolved error bodies, malformed responses, and network failures become `failed`.
- Failed installs resolve callback status to `error`, retain the key URL, and show the existing Copy Key URL and Tools > Registration instructions.
- Request failures no longer create unhandled promise rejections.

## Implementation Summary

- Consume and validate the `InstallKey.php` JSON response before marking installation successful.
- Preserve safe WebGUI JSON errors such as `download error 8` in the errors store.
- Add historical success fixtures for Unraid 6.12/7.0 and 7.1, plus array, malformed-message, and resolved-error rejection coverage.
- Retain real-Wretch regression coverage with controlled delayed responses.

## Verification

- Pre-fix compatibility proof: `pnpm test __test__/store/installKey.test.ts` — all 3 historical success fixtures failed by producing `failed` instead of `success`.
- `pnpm test __test__/store/installKey.test.ts __test__/store/installKey.wretch.test.ts __test__/store/callbackActions.helpers.test.ts __test__/components/CallbackFeedback.test.ts` — 4 files, 56 tests passed.
- `pnpm test` — 68 files passed, 666 tests passed, 6 skipped.
- `pnpm codegen` — passed with no retained generated changes.
- `pnpm type-check` — passed.
- `pnpm lint` — passed.
- `git diff --check` — passed.

## Risk

Low. The change remains isolated to client-side install response handling and tests. It does not change the request URL, server endpoint, key URL, trial issuance, retry behavior, or WebGUI installation logic. Historical behavior was verified from WebGUI release tags; no live key was issued or installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved key-installation response validation and error handling.
  - Installation failures now show clearer messages for invalid responses, server errors, and network issues.
  - Prevented installation requests from remaining unresolved or triggering unhandled errors.
  - Added manual recovery guidance for failed trial-key installations, including **Copy Key URL** and **Tools > Registration**.

- **Tests**
  - Expanded coverage for successful, failed, delayed, and network-error installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->