### PR TITLE
fix(plugin): clean stale web components from TXZ installs

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -34,9 +34,10 @@
     "env:validate": "test -f .env || (echo 'Error: .env file missing. Run npm run env:init first' && exit 1)",
     "env:clean": "rm -f .env",
     "// Testing": "",
-    "test": "vitest && pnpm run test:extractor && pnpm run test:shell-detection",
+    "test": "vitest && pnpm run test:extractor && pnpm run test:shell-detection && pnpm run test:txz-install",
     "test:extractor": "bash ./tests/test-extractor.sh",
-    "test:shell-detection": "bash ./tests/test-shell-detection.sh"
+    "test:shell-detection": "bash ./tests/test-shell-detection.sh",
+    "test:txz-install": "bash ./tests/test-txz-install.sh"
   },
   "devDependencies": {
     "http-server": "14.1.1",

--- a/plugin/source/dynamix.unraid.net/install/doinst.sh
+++ b/plugin/source/dynamix.unraid.net/install/doinst.sh
@@ -24,14 +24,6 @@ ln -sf ../local/bin/unraid-api usr/bin/unraid-api
 backup_file_if_exists usr/local/unraid-api/.env
 cp usr/local/unraid-api/.env.production usr/local/unraid-api/.env
 
-# auto-generated actions from makepkg:
-( cd usr/local/bin ; rm -rf corepack )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/corepack/dist/corepack.js corepack )
-( cd usr/local/bin ; rm -rf npm )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm )
-( cd usr/local/bin ; rm -rf npx )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx )
-
 remove_stale_component_files() {
   component_dir="usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
   [ -d "$component_dir" ] || return 0
@@ -60,6 +52,10 @@ remove_stale_component_files() {
 }
 
 remove_stale_component_files
+
+# makepkg appends generated symlink actions to this script when building the TXZ.
+# Keep those actions after the cleanup above.
+# auto-generated actions from makepkg:
 ( cd usr/local/bin ; rm -rf corepack )
 ( cd usr/local/bin ; ln -sf ../lib/node_modules/corepack/dist/corepack.js corepack )
 ( cd usr/local/bin ; rm -rf npm )

--- a/plugin/source/dynamix.unraid.net/install/doinst.sh
+++ b/plugin/source/dynamix.unraid.net/install/doinst.sh
@@ -52,13 +52,3 @@ remove_stale_component_files() {
 }
 
 remove_stale_component_files
-
-# makepkg appends generated symlink actions to this script when building the TXZ.
-# Keep those actions after the cleanup above.
-# auto-generated actions from makepkg:
-( cd usr/local/bin ; rm -rf corepack )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/corepack/dist/corepack.js corepack )
-( cd usr/local/bin ; rm -rf npm )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm )
-( cd usr/local/bin ; rm -rf npx )
-( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx )

--- a/plugin/source/dynamix.unraid.net/install/doinst.sh
+++ b/plugin/source/dynamix.unraid.net/install/doinst.sh
@@ -31,6 +31,35 @@ cp usr/local/unraid-api/.env.production usr/local/unraid-api/.env
 ( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm )
 ( cd usr/local/bin ; rm -rf npx )
 ( cd usr/local/bin ; ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx )
+
+remove_stale_component_files() {
+  component_dir="usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
+  [ -d "$component_dir" ] || return 0
+
+  package_db=""
+  for candidate in var/lib/pkgtools/packages/dynamix.unraid.net-* var/log/packages/dynamix.unraid.net-*; do
+    if [ -f "$candidate" ]; then
+      package_db="$candidate"
+      break
+    fi
+  done
+
+  if [ -z "$package_db" ]; then
+    echo "Warning: Cannot find the installed package file list; keeping component files"
+    return 0
+  fi
+
+  find "$component_dir" -type f -print | while IFS= read -r file; do
+    if ! grep -Fqx "$file" "$package_db"; then
+      echo "Removing stale component file: $file"
+      rm -f "$file"
+    fi
+  done
+
+  find "$component_dir" -depth -type d -empty -delete 2>/dev/null || true
+}
+
+remove_stale_component_files
 ( cd usr/local/bin ; rm -rf corepack )
 ( cd usr/local/bin ; ln -sf ../lib/node_modules/corepack/dist/corepack.js corepack )
 ( cd usr/local/bin ; rm -rf npm )

--- a/plugin/tests/test-txz-install.sh
+++ b/plugin/tests/test-txz-install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOINST_SCRIPT="$SCRIPT_DIR/../source/dynamix.unraid.net/install/doinst.sh"
+TEMP_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT
+
+COMPONENT_DIR="$TEMP_ROOT/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
+mkdir -p \
+  "$TEMP_ROOT/etc/rc.d/rc6.d" \
+  "$TEMP_ROOT/var/lib/pkgtools/packages" \
+  "$TEMP_ROOT/usr/local/bin" \
+  "$TEMP_ROOT/usr/local/sbin" \
+  "$TEMP_ROOT/usr/bin" \
+  "$TEMP_ROOT/usr/local/unraid-api/dist" \
+  "$COMPONENT_DIR/standalone"
+
+touch \
+  "$TEMP_ROOT/usr/local/unraid-api/dist/cli.js" \
+  "$TEMP_ROOT/usr/local/unraid-api/dist/main.js"
+printf '%s\n' production > "$TEMP_ROOT/usr/local/unraid-api/.env.production"
+printf '%s\n' current > "$COMPONENT_DIR/standalone/current.js"
+printf '%s\n' stale > "$COMPONENT_DIR/standalone/old.js"
+printf '%s\n' stale > "$COMPONENT_DIR/.stale"
+cat > "$TEMP_ROOT/var/lib/pkgtools/packages/dynamix.unraid.net-test" <<EOF
+PACKAGE NAME: dynamix.unraid.net-test
+FILE LIST:
+./
+usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/
+usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/
+usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/current.js
+EOF
+
+(
+  cd "$TEMP_ROOT"
+  sh "$DOINST_SCRIPT"
+)
+
+if [ ! -f "$COMPONENT_DIR/standalone/current.js" ]; then
+  echo "Package file cleanup removed a current component" >&2
+  exit 1
+fi
+
+if [ -e "$COMPONENT_DIR/standalone/old.js" ] || [ -e "$COMPONENT_DIR/.stale" ]; then
+  echo "Package file cleanup left stale components" >&2
+  exit 1
+fi
+
+echo "TXZ install cleanup test passed"

--- a/plugin/tests/test-txz-install.sh
+++ b/plugin/tests/test-txz-install.sh
@@ -51,6 +51,7 @@ run_case() {
   local component_dir
 
   root="$(mktemp -d)"
+  trap 'rm -rf "$root"' EXIT
   component_dir="$root/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
   prepare_root "$root"
 
@@ -97,6 +98,7 @@ run_case() {
   fi
 
   rm -rf "$root"
+  trap - EXIT
   echo "$case_name passed"
 }
 

--- a/plugin/tests/test-txz-install.sh
+++ b/plugin/tests/test-txz-install.sh
@@ -4,52 +4,103 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOINST_SCRIPT="$SCRIPT_DIR/../source/dynamix.unraid.net/install/doinst.sh"
-TEMP_ROOT="$(mktemp -d)"
 
-cleanup() {
-  rm -rf "$TEMP_ROOT"
+prepare_root() {
+  local root="$1"
+  local component_dir="$root/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
+
+  mkdir -p \
+    "$root/etc/rc.d/rc6.d" \
+    "$root/var/lib/pkgtools/packages" \
+    "$root/var/log/packages" \
+    "$root/usr/local/bin" \
+    "$root/usr/local/sbin" \
+    "$root/usr/bin" \
+    "$root/usr/local/unraid-api/dist" \
+    "$component_dir/standalone"
+
+  touch \
+    "$root/usr/local/unraid-api/dist/cli.js" \
+    "$root/usr/local/unraid-api/dist/main.js"
+  printf '%s\n' production > "$root/usr/local/unraid-api/.env.production"
+  printf '%s\n' current > "$component_dir/standalone/current.js"
+  printf '%s\n' stale > "$component_dir/standalone/old.js"
+  printf '%s\n' stale > "$component_dir/.stale"
 }
-trap cleanup EXIT
 
-COMPONENT_DIR="$TEMP_ROOT/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
-mkdir -p \
-  "$TEMP_ROOT/etc/rc.d/rc6.d" \
-  "$TEMP_ROOT/var/lib/pkgtools/packages" \
-  "$TEMP_ROOT/usr/local/bin" \
-  "$TEMP_ROOT/usr/local/sbin" \
-  "$TEMP_ROOT/usr/bin" \
-  "$TEMP_ROOT/usr/local/unraid-api/dist" \
-  "$COMPONENT_DIR/standalone"
+write_manifest() {
+  local manifest_path="$1"
+  local current_file="$2"
+  local stale_file="${3:-}"
 
-touch \
-  "$TEMP_ROOT/usr/local/unraid-api/dist/cli.js" \
-  "$TEMP_ROOT/usr/local/unraid-api/dist/main.js"
-printf '%s\n' production > "$TEMP_ROOT/usr/local/unraid-api/.env.production"
-printf '%s\n' current > "$COMPONENT_DIR/standalone/current.js"
-printf '%s\n' stale > "$COMPONENT_DIR/standalone/old.js"
-printf '%s\n' stale > "$COMPONENT_DIR/.stale"
-cat > "$TEMP_ROOT/var/lib/pkgtools/packages/dynamix.unraid.net-test" <<EOF
+  cat > "$manifest_path" <<EOF
 PACKAGE NAME: dynamix.unraid.net-test
 FILE LIST:
 ./
 usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/
 usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/
-usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/current.js
+$current_file
+$stale_file
 EOF
+}
 
-(
-  cd "$TEMP_ROOT"
-  sh "$DOINST_SCRIPT"
-)
+run_case() {
+  local case_name="$1"
+  local manifest_location="$2"
+  local root
+  local component_dir
 
-if [ ! -f "$COMPONENT_DIR/standalone/current.js" ]; then
-  echo "Package file cleanup removed a current component" >&2
-  exit 1
-fi
+  root="$(mktemp -d)"
+  component_dir="$root/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components"
+  prepare_root "$root"
 
-if [ -e "$COMPONENT_DIR/standalone/old.js" ] || [ -e "$COMPONENT_DIR/.stale" ]; then
-  echo "Package file cleanup left stale components" >&2
-  exit 1
-fi
+  case "$manifest_location" in
+    primary)
+      write_manifest \
+        "$root/var/lib/pkgtools/packages/dynamix.unraid.net-primary" \
+        "usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/current.js"
+      write_manifest \
+        "$root/var/log/packages/dynamix.unraid.net-legacy" \
+        "usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/old.js"
+      ;;
+    legacy)
+      write_manifest \
+        "$root/var/log/packages/dynamix.unraid.net-legacy" \
+        "usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/current.js"
+      ;;
+    none)
+      ;;
+    *)
+      echo "Unknown manifest location: $manifest_location" >&2
+      exit 1
+      ;;
+  esac
 
-echo "TXZ install cleanup test passed"
+  (
+    cd "$root"
+    sh "$DOINST_SCRIPT"
+  )
+
+  if [ ! -f "$component_dir/standalone/current.js" ]; then
+    echo "$case_name removed a current component" >&2
+    exit 1
+  fi
+
+  if [ "$manifest_location" = "none" ]; then
+    if [ ! -f "$component_dir/standalone/old.js" ] || [ ! -f "$component_dir/.stale" ]; then
+      echo "$case_name deleted files without a package manifest" >&2
+      exit 1
+    fi
+  elif [ -e "$component_dir/standalone/old.js" ] || [ -e "$component_dir/.stale" ]; then
+    echo "$case_name left stale components" >&2
+    exit 1
+  fi
+
+  rm -rf "$root"
+  echo "$case_name passed"
+}
+
+run_case "Primary manifest" primary
+run_case "Legacy manifest fallback" legacy
+run_case "Missing manifest fail-open" none
+echo "TXZ install cleanup tests passed"


### PR DESCRIPTION
## Summary

Fix stale hashed web component files when the API Slackware package is installed or reinstalled through the TXZ path.

## Why This Exists

The 7.3.2 image can contain both current and older web component bundles. The PLG cleanup does not run for the TXZ install path used by the package installer, so old bundles remain available to the legacy GUI and can contribute to the reported light-mode dark-root-class behavior.

## Resolution

The TXZ `install/doinst.sh` now runs a post-install cleanup that compares files under `unraid-components` with the newly installed package manifest in `/var/lib/pkgtools/packages` (with the legacy log location as fallback). Files not listed by the current package are removed; current package files are preserved.

The cleanup fails open if the package manifest cannot be found.

## Verification

- `bash -n plugin/source/dynamix.unraid.net/install/doinst.sh`
- `bash plugin/tests/test-txz-install.sh`
- `pnpm run test:extractor` — 62 passed
- `pnpm run test:shell-detection` — 4 passed
- Vitest — 35 passed
- QA VM investigation on Unraid 7.3.2 confirmed the TXZ path runs through Slackware `upgradepkg` and that cleanup belongs in the post-install pass.

## Risk

Low. Removal is limited to files below the web component directory and only targets files absent from the current package manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale component files during installation to prevent outdated files from remaining.
  * Preserved existing files when the installed package file list is unavailable.

* **Tests**
  * Added integration coverage verifying current files are retained and stale files are removed.
  * Included the installation test in the standard test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->