### PR TITLE
fix(connect): serialize nginx reload requests

### DIFF
--- a/api/src/unraid-api/nginx/nginx.service.spec.ts
+++ b/api/src/unraid-api/nginx/nginx.service.spec.ts
@@ -1,0 +1,36 @@
+import { execa } from 'execa';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NginxService } from '@app/unraid-api/nginx/nginx.service.js';
+
+vi.mock('execa', () => ({
+    execa: vi.fn(),
+}));
+
+describe('NginxService', () => {
+    const mockExeca = vi.mocked(execa);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('coalesces concurrent reload requests', async () => {
+        const firstService = new NginxService();
+        const secondService = new NginxService();
+
+        const results = await Promise.all([firstService.reload(), secondService.reload()]);
+
+        expect(results).toEqual([true, true]);
+        expect(mockExeca).toHaveBeenCalledTimes(1);
+        expect(mockExeca).toHaveBeenCalledWith('/etc/rc.d/rc.nginx', ['reload']);
+    });
+
+    it('allows a new reload after the previous one completes', async () => {
+        const service = new NginxService();
+
+        await service.reload();
+        await service.reload();
+
+        expect(mockExeca).toHaveBeenCalledTimes(2);
+    });
+});

--- a/api/src/unraid-api/nginx/nginx.service.ts
+++ b/api/src/unraid-api/nginx/nginx.service.ts
@@ -2,12 +2,30 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { execa } from 'execa';
 
+let activeReload: Promise<boolean> | undefined;
+
 @Injectable()
 export class NginxService {
     private readonly logger = new Logger(NginxService.name);
 
     /** reloads nginx via its rc script */
-    async reload() {
+    async reload(): Promise<boolean> {
+        if (activeReload) {
+            this.logger.debug('Nginx reload already in progress; waiting for it to complete');
+            return activeReload;
+        }
+
+        const reload = this.executeReload();
+        activeReload = reload;
+
+        try {
+            return await reload;
+        } finally {
+            activeReload = undefined;
+        }
+    }
+
+    private async executeReload(): Promise<boolean> {
         try {
             await execa('/etc/rc.d/rc.nginx', ['reload']);
             this.logger.log('Nginx reloaded');


### PR DESCRIPTION
## Summary

Concurrent Connect WAN-access transitions could start overlapping `rc.nginx` rebuilds. This change coalesces in-process reload requests so only one rebuild runs at a time.

## Why This Exists

The Unraid 7.3.2 `rc.nginx` script rebuilds the shared `servers.conf` file with truncating and append writes. Connect WAN-access event handlers run asynchronously, so overlapping reloads can write duplicate server blocks, make `nginx -t` fail, and make the local WebGUI unreachable.

## Resolution

`NginxService` now stores the active reload promise at module scope. Concurrent callers wait for that promise and receive the same result. A later caller starts a new reload after the active command completes.

This shape protects all `NginxService` instances in the API process and does not change the existing success or failure result.

## Reviewer Considerations

- Review the shared promise lifecycle and cleanup in `finally`.
- The gate prevents overlap inside one API process. It does not serialize an independently launched `rc.nginx` process from another OS process.
- This PR does not change the underlying Unraid `rc.nginx` script or the event sources.
- Bare-metal validation on Unraid 7.3.2 remains recommended.

## Behavior Changes

Concurrent API-triggered nginx reload requests now run one `rc.nginx reload` command. Sequential requests after completion still run normally.

## Implementation Summary

- Added an in-process reload gate to `api/src/unraid-api/nginx/nginx.service.ts`.
- Added regression tests for concurrent service instances and later reloads.

## Verification

- `pnpm --filter ./api exec vitest run src/unraid-api/nginx/nginx.service.spec.ts` — 2 passed.
- `pnpm --filter ./api exec vitest run src/unraid-api/nginx src/unraid-api/unraid-file-modifier` — 44 passed.
- `pnpm --filter ./api type-check` — passed.
- ESLint on the changed files — passed.
- GitHub API tests, builds, CodeQL, coverage, and CodeRabbit review — passed.
- Full local API Vitest run — 2,007 passed; 1 unrelated VMS suite failed because the native `@unraid/libvirt` module is unavailable in this environment.
- GitHub `Audit Dependencies` failed on existing transitive dependency advisories, including `postcss` and `tar`. This PR changes no dependency files.

## Risk

Low for API-triggered reloads. The remaining risk is limited to reloads started outside this API process.