### PR TITLE
refactor(array): retire direct disk removal mutation

### DIFF
--- a/api/generated-schema.graphql
+++ b/api/generated-schema.graphql
@@ -1192,11 +1192,6 @@ type ArrayMutations {
   """Add new disk to array"""
   addDiskToArray(input: ArrayDiskInput!): UnraidArray!
 
-  """
-  Remove existing disk from array. NOTE: The array must be stopped before running this otherwise it'll throw an error.
-  """
-  removeDiskFromArray(input: ArrayDiskInput!): UnraidArray!
-
   """Mount a disk in the array"""
   mountArrayDisk(id: PrefixedID!): ArrayDisk!
 

--- a/api/src/unraid-api/cli/generated/graphql.ts
+++ b/api/src/unraid-api/cli/generated/graphql.ts
@@ -313,8 +313,6 @@ export type ArrayMutations = {
   clearArrayDiskStatistics: Scalars['Boolean']['output'];
   /** Mount a disk in the array */
   mountArrayDisk: ArrayDisk;
-  /** Remove existing disk from array. NOTE: The array must be stopped before running this otherwise it'll throw an error. */
-  removeDiskFromArray: UnraidArray;
   /** Set array state */
   setState: UnraidArray;
   /** Unmount a disk from the array */
@@ -334,11 +332,6 @@ export type ArrayMutationsClearArrayDiskStatisticsArgs = {
 
 export type ArrayMutationsMountArrayDiskArgs = {
   id: Scalars['PrefixedID']['input'];
-};
-
-
-export type ArrayMutationsRemoveDiskFromArrayArgs = {
-  input: ArrayDiskInput;
 };
 
 

--- a/api/src/unraid-api/graph/resolvers/array/array.mutations.resolver.ts
+++ b/api/src/unraid-api/graph/resolvers/array/array.mutations.resolver.ts
@@ -39,18 +39,6 @@ export class ArrayMutationsResolver {
         return this.arrayService.addDiskToArray(input);
     }
 
-    @ResolveField(() => UnraidArray, {
-        description:
-            "Remove existing disk from array. NOTE: The array must be stopped before running this otherwise it'll throw an error.",
-    })
-    @UsePermissions({
-        action: AuthAction.UPDATE_ANY,
-        resource: Resource.ARRAY,
-    })
-    public async removeDiskFromArray(@Args('input') input: ArrayDiskInput): Promise<UnraidArray> {
-        return this.arrayService.removeDiskFromArray(input);
-    }
-
     @ResolveField(() => ArrayDisk, { description: 'Mount a disk in the array' })
     @UsePermissions({
         action: AuthAction.UPDATE_ANY,

--- a/api/src/unraid-api/graph/resolvers/array/array.resolver.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/array/array.resolver.spec.ts
@@ -19,7 +19,6 @@ describe('ArrayResolver', () => {
                     useValue: {
                         updateArrayState: vi.fn(),
                         addDiskToArray: vi.fn(),
-                        removeDiskFromArray: vi.fn(),
                         mountArrayDisk: vi.fn(),
                         unmountArrayDisk: vi.fn(),
                         clearArrayDiskStatistics: vi.fn(),

--- a/api/src/unraid-api/graph/resolvers/array/array.service.spec.ts
+++ b/api/src/unraid-api/graph/resolvers/array/array.service.spec.ts
@@ -305,26 +305,6 @@ describe('ArrayService', () => {
         });
     });
 
-    describe('removeDiskFromArray', () => {
-        const input: ArrayDiskInput = { id: 'test-disk', slot: 1 };
-
-        it('should remove disk from array when STOPPED', async () => {
-            const result = await service.removeDiskFromArray(input);
-            expect(result).toEqual(mockArrayData);
-            expect(mockEmcmd).toHaveBeenCalledWith({
-                changeDevice: 'apply',
-                'slotId.1': '',
-            });
-            expect(mockGetArrayDataUtil).toHaveBeenCalledTimes(1);
-        });
-
-        it('should throw ArrayRunningError when array is STARTED', async () => {
-            mockEmhttp.mockReturnValue({ var: { mdState: ArrayState.STARTED } } as any);
-            await expect(service.removeDiskFromArray(input)).rejects.toThrow(new ArrayRunningError());
-            expect(mockEmcmd).not.toHaveBeenCalled();
-        });
-    });
-
     describe('mountArrayDisk', () => {
         const diskId = 'test-disk';
 

--- a/api/src/unraid-api/graph/resolvers/array/array.service.ts
+++ b/api/src/unraid-api/graph/resolvers/array/array.service.ts
@@ -202,23 +202,6 @@ export class ArrayService {
         return this.getArrayData();
     }
 
-    async removeDiskFromArray(input: ArrayDiskInput): Promise<UnraidArray> {
-        if (await this.arrayIsRunning()) {
-            throw new ArrayRunningError();
-        }
-
-        const { slot } = input;
-        const slotStr = slot?.toString() ?? '';
-
-        // Remove disk
-        await emcmd({
-            changeDevice: 'apply',
-            [`slotId.${slotStr}`]: '',
-        });
-
-        return this.getArrayData();
-    }
-
     async mountArrayDisk(id: string): Promise<UnraidArray> {
         if (!(await this.arrayIsRunning())) {
             throw new BadRequestException('Array must be running to mount disks');


### PR DESCRIPTION
## What changed

- Remove the `removeDiskFromArray` GraphQL resolver and the service method that directly cleared an array slot.
- Remove the obsolete unit coverage for that independent mutation path.
- Regenerate the public schema and CLI types without the retired field.

## Why

Array removal is now coordinated by Core's reviewed, durable storage workflow in the task tray. Keeping a separate GraphQL mutation would allow callers to bypass evacuation, parity-preserving shrink, checkpoints, progress, and recovery handling.

## Verification

- Generated GraphQL schema and CLI types successfully.
- API ESLint passed.
- Array resolver/service tests: 22 passed.
- API TypeScript type-check passed.
- `rg removeDiskFromArray api` returns no matches.

## Coordination

Work intent: [U8-850](https://linear.app/lime-technology/issue/U8-850/make-storage-recovery-and-pool-drive-details-clear)

Companion changes: [Core #937](https://github.com/unraid/core/pull/937), [unraid-e2e #358](https://github.com/unraid/unraid-e2e/pull/358).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the disk-removal operation from the array management API.
  * Disk addition functionality remains available.
* **Bug Fixes**
  * Prevents unsupported disk-removal requests from being exposed or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI note

The dependency-audit job reports advisories in the existing lockfile (`nanoid`, `postcss`, and transitive `tar`, among others). This PR does not change `package.json`, `pnpm-lock.yaml`, or any dependency version. Source lint, focused tests, type-check, and generated contract checks pass.
